### PR TITLE
Cherry-pick `build_with_pause.bat` build script

### DIFF
--- a/build_with_pause.bat
+++ b/build_with_pause.bat
@@ -1,0 +1,2 @@
+call build.bat %1
+pause


### PR DESCRIPTION
(As it's not a part of the reader itself) in order to reduce differences with the experimental-reader-updated branch.