### PR TITLE
The key presses of cloned players can be modified with Player.keys

### DIFF
--- a/LunaDll/Misc/RuntimeHookComponents/RuntimeHookGeneral.cpp
+++ b/LunaDll/Misc/RuntimeHookComponents/RuntimeHookGeneral.cpp
@@ -630,6 +630,7 @@ void TrySkipPatch()
 
     PATCH(0xA755D2).CALL(&UpdateInputFinishHook_Wrapper).Apply();
     PATCH(0xA74910).JMP(&runtimeHookUpdateInput).Apply();
+	PATCH(0x9C4ADA).JMP(0x9C4B37).Apply(); //So the controls of cloned players can be modified during onInputUpdate
 
     PATCH(0x902D3D).CALL(&WorldOverlayHUDBitBltHook).Apply();
     PATCH(0x902DFC).CALL(&WorldOverlayHUDBitBltHook).Apply();

--- a/LunaDll/Misc/RuntimeHookComponents/RuntimeHookGeneral.cpp
+++ b/LunaDll/Misc/RuntimeHookComponents/RuntimeHookGeneral.cpp
@@ -630,7 +630,7 @@ void TrySkipPatch()
 
     PATCH(0xA755D2).CALL(&UpdateInputFinishHook_Wrapper).Apply();
     PATCH(0xA74910).JMP(&runtimeHookUpdateInput).Apply();
-	PATCH(0x9C4ADA).JMP(0x9C4B37).Apply(); //So the controls of cloned players can be modified during onInputUpdate
+    PATCH(0x9C4ADA).JMP(0x9C4B37).Apply(); //So the controls of cloned players can be modified during onInputUpdate
 
     PATCH(0x902D3D).CALL(&WorldOverlayHUDBitBltHook).Apply();
     PATCH(0x902DFC).CALL(&WorldOverlayHUDBitBltHook).Apply();

--- a/LunaDll/Misc/RuntimeHookComponents/RuntimeHookHooks.cpp
+++ b/LunaDll/Misc/RuntimeHookComponents/RuntimeHookHooks.cpp
@@ -776,13 +776,13 @@ int __stdcall replacement_VbaStrCmp(BSTR arg1, BSTR arg2) {
 
 static void __stdcall UpdateInputFinishHook()
 {
-	//https://github.com/smbx/smbx-legacy-source/blob/4a7ff946da8924d2268f6ee8d824034f3a7d7658/modPlayer.bas#L5959
-	int playerCount = GM_PLAYERS_COUNT;
-	if (playerCount > 2 && GM_LEVEL_MODE == 0 && GM_WINNING == 0 && GM_UNK_IS_CONNECTED == 0) {
-		for (int playerIdx = 2; playerIdx <= playerCount; playerIdx++) {
-			Player::Get(playerIdx)->keymap = Player::Get(1)->keymap;
-		}
-	}
+    //https://github.com/smbx/smbx-legacy-source/blob/4a7ff946da8924d2268f6ee8d824034f3a7d7658/modPlayer.bas#L5959
+    int playerCount = GM_PLAYERS_COUNT;
+    if (playerCount > 2 && GM_LEVEL_MODE == 0 && GM_WINNING == 0 && GM_UNK_IS_CONNECTED == 0) {
+        for (int playerIdx = 2; playerIdx <= playerCount; playerIdx++) {
+            Player::Get(playerIdx)->keymap = Player::Get(1)->keymap;
+        }
+    }
 
     g_EventHandler.hookInputUpdate();
 }

--- a/LunaDll/Misc/RuntimeHookComponents/RuntimeHookHooks.cpp
+++ b/LunaDll/Misc/RuntimeHookComponents/RuntimeHookHooks.cpp
@@ -779,7 +779,7 @@ static void __stdcall UpdateInputFinishHook()
 	//https://github.com/smbx/smbx-legacy-source/blob/4a7ff946da8924d2268f6ee8d824034f3a7d7658/modPlayer.bas#L5959
 	int playerCount = GM_PLAYERS_COUNT;
 	if (playerCount > 2 && GM_LEVEL_MODE == 0 && GM_WINNING == 0 && GM_UNK_IS_CONNECTED == 0) {
-		for (int playerIdx = 2; playerIdx < playerCount; playerIdx++) {
+		for (int playerIdx = 2; playerIdx <= playerCount; playerIdx++) {
 			Player::Get(playerIdx)->keymap = Player::Get(1)->keymap;
 		}
 	}

--- a/LunaDll/Misc/RuntimeHookComponents/RuntimeHookHooks.cpp
+++ b/LunaDll/Misc/RuntimeHookComponents/RuntimeHookHooks.cpp
@@ -776,6 +776,14 @@ int __stdcall replacement_VbaStrCmp(BSTR arg1, BSTR arg2) {
 
 static void __stdcall UpdateInputFinishHook()
 {
+	//https://github.com/smbx/smbx-legacy-source/blob/4a7ff946da8924d2268f6ee8d824034f3a7d7658/modPlayer.bas#L5959
+	int playerCount = GM_PLAYERS_COUNT;
+	if (playerCount > 2 && GM_LEVEL_MODE == 0 && GM_WINNING == 0 && GM_UNK_IS_CONNECTED == 0) {
+		for (int playerIdx = 2; playerIdx < playerCount; playerIdx++) {
+			Player::Get(playerIdx)->keymap = Player::Get(1)->keymap;
+		}
+	}
+
     g_EventHandler.hookInputUpdate();
 }
 


### PR DESCRIPTION
For some reason, the keys of cloned players are set to the first player's keys in the clown car subroutine, which happens after `onTick`. Because of that, the cloned players will always mimic player 1, even if their keys are modified during `onInputUpdate`. To fix this issue, I patched the clown car subroutine to skip the key updating code and I rewrote it in the `UpdateInputFinishHook` procedure to make sure it is executed right before `onInputUpdate`.

Example using the `supermario4` cheat code and the following lua code:
```lua
function onInputUpdate()
    if Player.count() > 2 then
        Player(3).keys.right = KEYS_PRESSED
    end
end
```

Before:
![2021-08-01_03_54_36](https://user-images.githubusercontent.com/12142048/127757911-ab71c8af-8e70-43cc-adff-15a75d897564.gif)

After:
![2021-08-01_04_04_11](https://user-images.githubusercontent.com/12142048/127757919-11561644-4004-4b18-aa9c-6547d22f2ad9.gif)
