### PR TITLE
Fence fixes enhancements

### DIFF
--- a/LunaDll/LuaMain/LunaLuaMain.cpp
+++ b/LunaDll/LuaMain/LunaLuaMain.cpp
@@ -123,6 +123,9 @@ bool CLunaLua::shutdown()
     gDisablePlayerDownwardClipFix.Apply();
     gDisableNPCDownwardClipFix.Apply();
     gDisableNPCDownwardClipFixSlope.Apply();
+    for (int i = 0; gFenceFixes[i] != nullptr; i++) {
+        gFenceFixes[i]->Apply();
+    }
 
     // Request cached images/sounds/files be held onto for now
     LunaImage::holdCachedImages(m_type == LUNALUA_WORLD);


### PR DESCRIPTION
Fence patches are now applied during shutdown like other fixes. Also made modified versions of [`ffi_misc.lua`](https://gist.github.com/Supermario1313/2c31e60af831727055b7e2aa9834cbea#file-ffi_misc-lua) and [`ffi_player.lua`](https://gist.github.com/Supermario1313/2c31e60af831727055b7e2aa9834cbea#file-ffi_player-lua) which add `Misc.SetFenceBugFix(enable)` and `player.climbingBGO` to the LunaLua API.