### PR TITLE
Make luabind classes compatible with type.lua

### DIFF
--- a/LunaDll/libs/luabind-include/luabind/make_function.hpp
+++ b/LunaDll/libs/luabind-include/luabind/make_function.hpp
@@ -114,10 +114,9 @@ object make_function(lua_State* L, F f, Signature, Policies)
 template <class F>
 object make_function(lua_State* L, F f)
 {
-    return make_function(L, detail::deduce_signature(f), detail::null_type());
+    return make_function(L, f, detail::deduce_signature(f), detail::null_type()); // https://stackoverflow.com/a/17729743
 }
 
 } // namespace luabind
 
 #endif // LUABIND_MAKE_FUNCTION_081014_HPP
-


### PR DESCRIPTION
`type(...)` is now compatible with luabind classes like `Level`, `Path` or `Scenery`.

Example using the following Lua code in `map.lua`:

```lua
function onDraw()
    Text.print(type(Level.get()[1]), 66, 130)
end
```

Before:
![2022-02-27_02_58_07](https://user-images.githubusercontent.com/12142048/156020263-f38df040-09a0-49fe-aac8-9165c9db07e1.png)

After:
![2022-02-27_04_15_33](https://user-images.githubusercontent.com/12142048/156020308-c4679819-dead-44ac-aa77-2634fdceb712.png)