### PR TITLE
Fix crash on onNPCHarm cancellation

### DIFF
--- a/LunaDll/Misc/RuntimeHookComponents/RuntimeHookNpcHarm.cpp
+++ b/LunaDll/Misc/RuntimeHookComponents/RuntimeHookNpcHarm.cpp
@@ -2675,6 +2675,8 @@ __declspec(naked) void __stdcall runtimeHookNpcHarmRaw_a2d79f(void)
         pop ecx
         pop eax
         popfd
+        push 0xa2d917
+        ret
     safe:
         push 0xa2d7a5
         ret
@@ -2708,6 +2710,8 @@ __declspec(naked) void __stdcall runtimeHookNpcHarmRaw_a2d7ae(void)
         pop ecx
         pop eax
         popfd
+        push 0xa2d917
+        ret
     safe:
         push 0xa2d7b4
         ret


### PR DESCRIPTION
Cancelling `onNPCHarm` can crash the game in some situations. I fixed one of them but there might be other ones ([rixi's hammer bro crash](https://discord.com/channels/215661302692052992/216613837716062218/872313565535670352) could be one of them), hence why this pull request is still a draft.