### PR TITLE
Add Misc.getLoadingFinished

### DIFF
--- a/LunaDll/Misc/LoadScreen.cpp
+++ b/LunaDll/Misc/LoadScreen.cpp
@@ -39,6 +39,13 @@ static bool checkElapsedTime(lua_State* L, DWORD loadScreenStartTick)
     return true;
 }
 
+static void setFinishedFlag(lua_State* L)
+{
+    lua_pushboolean(L, killThreadFlag);
+    lua_setglobal(L, "_loadScreenFinished");
+}
+
+
 static void LoadThread(void)
 {
     DWORD loadScreenStartTick = GetTickCount();
@@ -96,6 +103,7 @@ static void LoadThread(void)
 
         lua_pushnumber(L, 0.0);
         lua_setglobal(L, "_loadScreenTimeout");
+        setFinishedFlag(L);
 
         luasetconst(L, "FIELD_BYTE", 1);
         luasetconst(L, "FIELD_WORD", 2);
@@ -162,6 +170,8 @@ static void LoadThread(void)
 
     
     do {
+        setFinishedFlag(L);
+        
         lua_getglobal(L, "onDraw");
         if (lua_pcall(L, 0, 0, 0))
         {

--- a/LunaDll/Misc/LoadScreen.cpp
+++ b/LunaDll/Misc/LoadScreen.cpp
@@ -39,10 +39,10 @@ static bool checkElapsedTime(lua_State* L, DWORD loadScreenStartTick)
     return true;
 }
 
-static void setFinishedFlag(lua_State* L)
+static void updateFinishedFlag(lua_State* L)
 {
     lua_pushboolean(L, killThreadFlag);
-    lua_setglobal(L, "_loadScreenFinished");
+    lua_setglobal(L, "_loadingFinished");
 }
 
 
@@ -103,7 +103,7 @@ static void LoadThread(void)
 
         lua_pushnumber(L, 0.0);
         lua_setglobal(L, "_loadScreenTimeout");
-        setFinishedFlag(L);
+        updateFinishedFlag(L);
 
         luasetconst(L, "FIELD_BYTE", 1);
         luasetconst(L, "FIELD_WORD", 2);
@@ -170,7 +170,7 @@ static void LoadThread(void)
 
     
     do {
-        setFinishedFlag(L);
+        updateFinishedFlag(L);
         
         lua_getglobal(L, "onDraw");
         if (lua_pcall(L, 0, 0, 0))

--- a/build.bat
+++ b/build.bat
@@ -2,4 +2,4 @@
 if "%1"=="" SET CONFIG=Release
 if NOT "%1"=="" SET CONFIG=%1
 
-"C:\Program Files (x86)\MSBuild\14.0\Bin\MSBuild.exe" LunaDll.sln /m /nologo /p:Configuration="%CONFIG%" /p:Platfprm="Win32"
+"C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\MSBuild\Current\Bin\amd64\MSBuild.exe" LunaDll.sln /m /nologo /p:Configuration="%CONFIG%" /p:Platfprm="Win32"

--- a/build.bat
+++ b/build.bat
@@ -2,4 +2,4 @@
 if "%1"=="" SET CONFIG=Release
 if NOT "%1"=="" SET CONFIG=%1
 
-"C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\MSBuild\Current\Bin\amd64\MSBuild.exe" LunaDll.sln /m /nologo /p:Configuration="%CONFIG%" /p:Platfprm="Win32"
+"C:\Program Files (x86)\MSBuild\14.0\Bin\MSBuild.exe" LunaDll.sln /m /nologo /p:Configuration="%CONFIG%" /p:Platfprm="Win32"


### PR DESCRIPTION
Adds a function to detect if the load screen is done loading, and is only continuing due to Misc.setLoadScreenTimeout. [Requires a change to loadscreen.lua](https://cdn.discordapp.com/attachments/739951186857427005/979823114743582811/loadscreen.lua), and works similarly to Misc.setLoadScreenTimeout (in that it uses a global lua variable).

Example use case is a load screen with an animation when it finishes loading to transition to the level, like so:
```lua
if Misc.getLoadingFinished() then
    loadingFinishedTimer = loadingFinishedTimer + 1
end

if loadingFinishedTimer <= loadingExitDuration then
    Misc.setLoadScreenTimeout(30)
else
    Misc.setLoadScreenTimeout(0)
end
```
... Or writing to a file with loadscreen-side data for the level:
```lua
if Misc.getLoadingFinished() then
    local f = io.open(episodePath.. "myFile.txt","w")
    
    f:write(tostring(myTimer))
    f:close()
end
```