### PR TITLE
Collision groups system

### DIFF
--- a/LunaDll/LuaMain/LuaProxyFFI.cpp
+++ b/LunaDll/LuaMain/LuaProxyFFI.cpp
@@ -421,6 +421,7 @@ extern "C" {
 typedef struct ExtendedNPCFields_\
 {\
     bool noblockcollision;\
+    char* collisionGroup;\
 } ExtendedNPCFields;";
     }
 
@@ -438,6 +439,7 @@ typedef struct ExtendedBlockFields_\
     double layerSpeedY;\
     double extraSpeedX;\
     double extraSpeedY;\
+    char* collisionGroup;\
 } ExtendedBlockFields;";
     }
 

--- a/LunaDll/LuaMain/LuaProxyFFI.cpp
+++ b/LunaDll/LuaMain/LuaProxyFFI.cpp
@@ -421,7 +421,7 @@ extern "C" {
 typedef struct ExtendedNPCFields_\
 {\
     bool noblockcollision;\
-    char* collisionGroup;\
+    char collisionGroup[32];\
 } ExtendedNPCFields;";
     }
 
@@ -439,8 +439,13 @@ typedef struct ExtendedBlockFields_\
     double layerSpeedY;\
     double extraSpeedX;\
     double extraSpeedY;\
-    char* collisionGroup;\
+    char collisionGroup[32];\
 } ExtendedBlockFields;";
+    }
+
+    FFI_EXPORT(int) LunaLuaGetCollisionGroupStringLength()
+    {
+        return 32;
     }
 
     FFI_EXPORT(void) LunaLuaSetPlayerFilterBounceFix(bool enable)

--- a/LunaDll/Misc/RuntimeHook.h
+++ b/LunaDll/Misc/RuntimeHook.h
@@ -475,6 +475,7 @@ void __stdcall runtimeHookNPCNoBlockCollisionA1760E(void);
 void __stdcall runtimeHookNPCNoBlockCollisionA1B33F(void);
 
 void __stdcall runtimeHookBlockNPCFilter(void);
+void __stdcall runtimeHookNPCCollisionGroup(void);
 
 void __stdcall runtimeHookLevelPauseCheck(void);
 

--- a/LunaDll/Misc/RuntimeHookComponents/RuntimeHookGeneral.cpp
+++ b/LunaDll/Misc/RuntimeHookComponents/RuntimeHookGeneral.cpp
@@ -1614,7 +1614,11 @@ void TrySkipPatch()
     PATCH(0x9E3E54).JMP(runtimeHookPSwitchGetNewBlockAtEndWrapper).NOP_PAD_TO_SIZE<29>().Apply();
 
     // Patch to handle blocks that allow NPCs to pass through
+    // Also handles collisionGroup for NPC-to-solid interactions now
     PATCH(0xA11B76).JMP(runtimeHookBlockNPCFilter).NOP_PAD_TO_SIZE<7>().Apply();
+
+    // Patch to handle collisionGroup for NPC-to-NPC interactions
+    PATCH(0xA181AD).JMP(runtimeHookNPCCollisionGroup).NOP_PAD_TO_SIZE<6>().Apply();
 
     // Replace pause button detection code to avoid re-triggering when held
     PATCH(0x8CA405).JMP(runtimeHookLevelPauseCheck).NOP_PAD_TO_SIZE<6>().Apply();

--- a/LunaDll/Misc/RuntimeHookComponents/RuntimeHookHooks.cpp
+++ b/LunaDll/Misc/RuntimeHookComponents/RuntimeHookHooks.cpp
@@ -3399,7 +3399,6 @@ static unsigned int __stdcall runtimeHookBlockNPCFilterInternal(unsigned int hit
 
         ExtendedNPCFields* ext = NPC::GetRawExtended(npcIdx);
 
-        // FIXME: Crashes on level reload. Probably just lacking a sanity check
         if (ext->collisionGroup[0] != 0) // Collision group string isn't empty
         {
             if (block->OwnerNPCID != 0) // Belongs to an NPC
@@ -3444,9 +3443,11 @@ __declspec(naked) void __stdcall runtimeHookBlockNPCFilter(void)
 
 static unsigned int __stdcall runtimeHookNPCCollisionGroupInternal(unsigned int npcAIdx, unsigned int npcBIdx)
 {
+    if (npcAIdx == npcBIdx) // Don't collide if it's the same NPC - this is what the code we're replacing does!
+        return 0; // Collision cancelled
+    
     ExtendedNPCFields* extA = NPC::GetRawExtended(npcAIdx);
 
-    // FIXME: Crashes on level reload. Probably just lacking a sanity check
     if (extA->collisionGroup[0] != 0) // Collision group string isn't empty
     {
         ExtendedNPCFields* extB = NPC::GetRawExtended(npcBIdx);

--- a/LunaDll/SMBXInternal/Blocks.h
+++ b/LunaDll/SMBXInternal/Blocks.h
@@ -35,12 +35,12 @@ struct Block : SMBX_FullBaseItemArray<Block, 2000, GM_BLOCK_COUNT_CONSTPTR, GM_B
     short               Unknown58;                          // 0x58
     short               IsInvisible2;                       // 0x5A
     unsigned short      IsInvisible3;                       // 0x5C (todo: verify!)
-    short               Unknown5E;                          // 0x5E
-    short               Unknown60;                          // 0x60
 
+    short               OwnerPlayerIdx;                     // 0x5E For temporary player blocks (clown cars)
+    short               OwnerNPCID;                         // 0x60 For temporary NPC blocks
     short               Unknown62;                          // 0x62
     short               Unknown64;                          // 0x64
-    short               Unknown66;                          // 0x66
+    short               OwnerNPCIdx;                        // 0x66 For temporary NPC blocks
 
 };
 #pragma pack(pop)
@@ -57,6 +57,7 @@ struct ExtendedBlockFields
     double layerSpeedY;
     double extraSpeedX;
     double extraSpeedY;
+    char* collisionGroup;
 
     // Constructor
     ExtendedBlockFields()
@@ -71,6 +72,7 @@ struct ExtendedBlockFields
         layerSpeedY = 0.0;
         extraSpeedX = 0.0;
         extraSpeedY = 0.0;
+        collisionGroup = "";
     }
 };
 

--- a/LunaDll/SMBXInternal/Blocks.h
+++ b/LunaDll/SMBXInternal/Blocks.h
@@ -57,7 +57,7 @@ struct ExtendedBlockFields
     double layerSpeedY;
     double extraSpeedX;
     double extraSpeedY;
-    char* collisionGroup;
+    char collisionGroup[32];
 
     // Constructor
     ExtendedBlockFields()
@@ -72,7 +72,7 @@ struct ExtendedBlockFields
         layerSpeedY = 0.0;
         extraSpeedX = 0.0;
         extraSpeedY = 0.0;
-        collisionGroup = "";
+        collisionGroup[0] = 0;
     }
 };
 

--- a/LunaDll/SMBXInternal/NPCs.h
+++ b/LunaDll/SMBXInternal/NPCs.h
@@ -520,6 +520,7 @@ static_assert(sizeof(NPCMOB) == 0x158, "sizeof(NPCMOB) must be 0x158");
 struct ExtendedNPCFields
 {
     bool noblockcollision;
+    char* collisionGroup;
 
     // Constructor
     ExtendedNPCFields()
@@ -531,6 +532,7 @@ struct ExtendedNPCFields
     void Reset()
     {
         noblockcollision = false;
+        collisionGroup = "";
     }
 };
 

--- a/LunaDll/SMBXInternal/NPCs.h
+++ b/LunaDll/SMBXInternal/NPCs.h
@@ -520,7 +520,7 @@ static_assert(sizeof(NPCMOB) == 0x158, "sizeof(NPCMOB) must be 0x158");
 struct ExtendedNPCFields
 {
     bool noblockcollision;
-    char* collisionGroup;
+    char collisionGroup[32];
 
     // Constructor
     ExtendedNPCFields()
@@ -532,7 +532,7 @@ struct ExtendedNPCFields
     void Reset()
     {
         noblockcollision = false;
-        collisionGroup = "";
+        collisionGroup[0] = 0;
     }
 };
 


### PR DESCRIPTION
Requires changes to [ffi_npc.lua](https://cdn.discordapp.com/attachments/739951186857427005/988591725591281774/ffi_npc.lua) and [ffi_block.lua](https://cdn.discordapp.com/attachments/739951186857427005/988591725255753748/ffi_block.lua).

Adds a system where if a block/NPC share the same string (and they aren't empty), they will ignore each other's collision. Made for use by the new chain chomps.