### PR TITLE
Additional events and NPC:collect

### DIFF
--- a/LunaDll/Defines.h
+++ b/LunaDll/Defines.h
@@ -719,6 +719,10 @@ DEFMEM(IMP_vbaInputFile, void*, 0x00401158); // Ptr to __cdecl
 //      Arg3 = short* The Object Index
 #define GF_NPC_COLLIDES     0x00A281B0
 
+//      Arg1 = short* The index of the player collecting it
+//      Arg2 = short* The index of the NPC collected
+#define GF_NPC_COLLECT      0x00A24CD0
+
 //      Arg1 = Momentum* The location for the bomb explosion
 //      Arg2 = short* Bomb explosion type
 //      Arg3 = short* Player index
@@ -858,6 +862,8 @@ static const auto native_setupSFX       = (void(__stdcall *)())GM_SETUP_SFX;
 static const auto native_cleanupKillNPC = (void(__stdcall *)(short* /**/, short* /**/))GF_NPC_CLEANUP;
 
 static const auto native_collideNPC     = (void(__stdcall *)(short* /*npcIndexToCollide*/, CollidersType* /*typeOfObject*/, short* /*objectIndex*/))GF_NPC_COLLIDES;
+
+static const auto native_collectNPC     = (void(__stdcall *)(short* /*playerIdx*/, short* /*npcIdx*/))GF_NPC_COLLECT;
 
 static const auto native_doBomb         = (void(__stdcall *)(Momentum* /*position*/, short* /*bombType*/, short* /*player index*/))GF_DO_BOMB;
 static const auto native_npcToCoins     = (void(__stdcall *)())GF_NPC_TO_COINS;

--- a/LunaDll/LuaMain/LuaProxyFFI.cpp
+++ b/LunaDll/LuaMain/LuaProxyFFI.cpp
@@ -94,6 +94,13 @@ extern "C" {
         }
     }
 
+    FFI_EXPORT(void) LunaLuaNPCCollect(short npcIdx, short playerIdx)
+    {
+        short targetIndex = npcIdx + 1;
+
+        native_collectNPC(&playerIdx, &targetIndex);
+    }
+
     #pragma comment(lib, "psapi.lib")
     struct LunaLuaMemUsageData
     {

--- a/LunaDll/LuaMain/LuaProxyFFI.cpp
+++ b/LunaDll/LuaMain/LuaProxyFFI.cpp
@@ -94,13 +94,6 @@ extern "C" {
         }
     }
 
-    FFI_EXPORT(void) LunaLuaNPCCollect(short npcIdx, short playerIdx)
-    {
-        short targetIndex = npcIdx + 1;
-
-        native_collectNPC(&playerIdx, &targetIndex);
-    }
-
     #pragma comment(lib, "psapi.lib")
     struct LunaLuaMemUsageData
     {

--- a/LunaDll/LuaMain/LunaLuaMain.cpp
+++ b/LunaDll/LuaMain/LunaLuaMain.cpp
@@ -1185,6 +1185,7 @@ void CLunaLua::bindAll()
                     def("_setSemisolidCollidingFlyType", &NPC::SetSemisolidCollidingFlyType),
                     def("_npcHarmCombo", NPC::HarmCombo),
                     def("_npcHarmComboWithDamage", NPC::HarmComboWithDamage),
+                    def("_npcCollect", NPC::Collect),
                     def("_playerHarm", Player::Harm),
                     def("_playerKill", Player::Kill)
                     //def("doBombExplosion", (void(*)(double, double, short, const LuaProxy::Player&))&LuaProxy::Misc::doBombExplosion)

--- a/LunaDll/Misc/RuntimeHook.h
+++ b/LunaDll/Misc/RuntimeHook.h
@@ -278,6 +278,9 @@ void __stdcall runtimeHookCleanupWorld(void);
 void __stdcall runtimeHookPiranahDivByZero();
 
 void __stdcall runtimeHookHitBlock(unsigned short* blockIndex, short* fromUpSide, unsigned short* playerIdx);
+void __stdcall runtimeHookRemoveBlock(unsigned short* blockIndex, short* makeEffects);
+
+void __stdcall runtimeHookCollectNPC(short* playerIdx, short* npcIdx);
 
 void __stdcall runtimeHookLogCollideNpc(DWORD addr, short* pNpcIdx, CollidersType* pObjType, short* pObjIdx);
 void __stdcall runtimeHookCollideNpc(short* pNpcIdx, CollidersType* pObjType, short* pObjIdx);

--- a/LunaDll/Misc/RuntimeHookComponents/RuntimeHookGeneral.cpp
+++ b/LunaDll/Misc/RuntimeHookComponents/RuntimeHookGeneral.cpp
@@ -1705,6 +1705,10 @@ void TrySkipPatch()
 
     // Hook block hits
     PATCH(0x9DA620).JMP(&runtimeHookHitBlock).NOP_PAD_TO_SIZE<6>().Apply();
+    PATCH(0x9E0D50).JMP(&runtimeHookRemoveBlock).NOP_PAD_TO_SIZE<6>().Apply();
+
+    // Hook for onNPCCollect
+    PATCH(0xA24CD0).JMP(&runtimeHookCollectNPC).NOP_PAD_TO_SIZE<6>().Apply();
 
     // Patch 16384 block bug
     PATCH(0xA98936).bytes(

--- a/LunaDll/Misc/RuntimeHookComponents/RuntimeHookHooks.cpp
+++ b/LunaDll/Misc/RuntimeHookComponents/RuntimeHookHooks.cpp
@@ -2206,6 +2206,35 @@ void __stdcall runtimeHookHitBlock(unsigned short* blockIndex, short* fromUpSide
     }
 }
 
+static _declspec(naked) void __stdcall removeBlock_OrigFunc(unsigned short* blockIndex, short* makeEffects)
+{
+    __asm {
+        PUSH EBP
+        MOV EBP, ESP
+        SUB ESP, 0x8
+        PUSH 0x9E0D56
+        RET
+    }
+}
+
+void __stdcall runtimeHookRemoveBlock(unsigned short* blockIndex, short* makeEffects)
+{
+    bool isCancelled = false;
+
+    if (gLunaLua.isValid()) {
+        std::shared_ptr<Event> blockRemoveEvent = std::make_shared<Event>("onBlockRemove", true);
+        blockRemoveEvent->setDirectEventName("onBlockRemove");
+        blockRemoveEvent->setLoopable(false);
+        gLunaLua.callEvent(blockRemoveEvent, *blockIndex, *makeEffects != 0);
+        isCancelled = blockRemoveEvent->native_cancelled();
+    }
+
+    if (!isCancelled)
+    {
+        removeBlock_OrigFunc(blockIndex, makeEffects);
+    }
+}
+
 static void __stdcall runtimeHookColorSwitch(unsigned int color)
 {
     if (gLunaLua.isValid()) {
@@ -2359,6 +2388,37 @@ _declspec(naked) void __stdcall runtimeHookColorSwitchRedBlock(void)
         ret
     }
 }
+
+
+static _declspec(naked) void __stdcall collectNPC_OrigFunc(short* playerIdx, short* npcIdx)
+{
+    __asm {
+        PUSH EBP
+        MOV EBP, ESP
+        SUB ESP, 0x8
+        PUSH 0xA24CD6
+        RET
+    }
+}
+
+void __stdcall runtimeHookCollectNPC(short* playerIdx, short* npcIdx)
+{
+    bool isCancelled = false;
+
+    if (gLunaLua.isValid()) {
+        std::shared_ptr<Event> npcCollectEvent = std::make_shared<Event>("onNPCCollect", true);
+        npcCollectEvent->setDirectEventName("onNPCCollect");
+        npcCollectEvent->setLoopable(false);
+        gLunaLua.callEvent(npcCollectEvent, *npcIdx, *playerIdx);
+        isCancelled = npcCollectEvent->native_cancelled();
+    }
+
+    if (!isCancelled)
+    {
+        collectNPC_OrigFunc(playerIdx, npcIdx);
+    }
+}
+
 
 static void drawReplacementSplashScreen(void)
 {

--- a/LunaDll/Misc/RuntimeHookComponents/RuntimeHookHooks.cpp
+++ b/LunaDll/Misc/RuntimeHookComponents/RuntimeHookHooks.cpp
@@ -2225,7 +2225,7 @@ void __stdcall runtimeHookRemoveBlock(unsigned short* blockIndex, short* makeEff
         std::shared_ptr<Event> blockRemoveEvent = std::make_shared<Event>("onBlockRemove", true);
         blockRemoveEvent->setDirectEventName("onBlockRemove");
         blockRemoveEvent->setLoopable(false);
-        gLunaLua.callEvent(blockRemoveEvent, *blockIndex, *makeEffects != 0);
+        gLunaLua.callEvent(blockRemoveEvent, *blockIndex, *makeEffects != 0, false);
         isCancelled = blockRemoveEvent->native_cancelled();
     }
 

--- a/LunaDll/Misc/RuntimeHookComponents/RuntimeHookHooks.cpp
+++ b/LunaDll/Misc/RuntimeHookComponents/RuntimeHookHooks.cpp
@@ -2404,7 +2404,7 @@ static _declspec(naked) void __stdcall collectNPC_OrigFunc(short* playerIdx, sho
 void __stdcall runtimeHookCollectNPC(short* playerIdx, short* npcIdx)
 {
     PlayerMOB* player = Player::Get(*playerIdx);
-    NPCMOB* npc = NPC::Get(*npcIdx - 1);
+    NPCMOB* npc = NPC::GetRaw(*npcIdx);
 
     // Duplicate of logic in TouchBonus
     if (npc->cantHurtPlayerIndex == *playerIdx && !(isCoin_ptr[npc->id] && player->HeldNPCIndex != *npcIdx && npc->killFlag == 0))

--- a/LunaDll/SMBXInternal/NPCs.cpp
+++ b/LunaDll/SMBXInternal/NPCs.cpp
@@ -253,6 +253,14 @@ short NPC::HarmComboWithDamage(short npcIdx, short harmType, short multiplier, f
     return multiplier;
 }
 
+void NPC::Collect(short npcIdx, short playerIdx)
+{
+    // Collect an NPC as if a player had touched it
+    short targetIndex = npcIdx + 1;
+
+    native_collectNPC(&playerIdx, &targetIndex);
+}
+
 // Declerations of inbuilt NPC property arrays
 static uint32_t npcprop_vulnerableharmtypes[NPC::MAX_ID + 1] = { 0 };
 static int16_t npcprop_spinjumpsafe[NPC::MAX_ID+1] = { 0 };

--- a/LunaDll/SMBXInternal/NPCs.h
+++ b/LunaDll/SMBXInternal/NPCs.h
@@ -488,8 +488,8 @@ struct NPCMOB {
     short offscreenFlag2;                   //+0x128
     short offscreenCountdownTimer;          //+0x12A
     short grabbingPlayerIndex;              //+0x12C
-    short grabTimer;                        //+0x12E
-    short unknown_130;                      //+0x130
+    short cantHurtTimer;                    //+0x12E
+    short cantHurtPlayerIndex;              //+0x130
     short unknown_132;                      //+0x132
     short unknown_134;                      //+0x134
     short collidesWithNPC;                  //+0x136

--- a/LunaDll/SMBXInternal/NPCs.h
+++ b/LunaDll/SMBXInternal/NPCs.h
@@ -565,6 +565,8 @@ namespace NPC {
     short HarmCombo(short npcIdx, short harmType, short multiplier);
     short HarmComboWithDamage(short npcIdx, short harmType, short multiplier, float damage);
 
+    void Collect(short npcIdx, short playerIdx);
+
     void InitProperties();
     uint32_t GetVulnerableHarmTypes(int id);
     bool GetSpinjumpSafe(int id);


### PR DESCRIPTION
Adds the following events: onBlockRemove(eventObj, block, makeEffects), onBlockDelete(eventObj, block), onNPCCollect(eventObj, npc, playerObj) and their respective "post" versions. Also adds NPC:collect(playerObj).

_I'm glad I could just reuse onBlockHit's code for most of that._

Requires the following changed lua files: [ffi_npc](https://cdn.discordapp.com/attachments/739951186857427005/1002347278754906183/ffi_npc.lua), [ffi_block](https://cdn.discordapp.com/attachments/739951186857427005/1002347279035928656/ffi_block.lua), and [main_events](https://cdn.discordapp.com/attachments/739951186857427005/1002347279342116924/main_events.lua).

If this is accepted, npcManager.collected should be deprecated and anything that uses it should be replaced with onPostNPCCollect.