### PR TITLE
Fix player passthrough slopes

### DIFF
--- a/LunaDll/Misc/RuntimeHook.h
+++ b/LunaDll/Misc/RuntimeHook.h
@@ -474,6 +474,8 @@ void __stdcall runtimeHookNPCNoBlockCollisionA113B0(void);
 void __stdcall runtimeHookNPCNoBlockCollisionA1760E(void);
 void __stdcall runtimeHookNPCNoBlockCollisionA1B33F(void);
 
+void __stdcall runtimeHookBlockPlayerFilter(void);
+
 void __stdcall runtimeHookBlockNPCFilter(void);
 void __stdcall runtimeHookNPCCollisionGroup(void);
 

--- a/LunaDll/Misc/RuntimeHookComponents/RuntimeHookCharacterId.cpp
+++ b/LunaDll/Misc/RuntimeHookComponents/RuntimeHookCharacterId.cpp
@@ -19,7 +19,7 @@ static int __stdcall runtimeHookCharacterIdTranslateHook(short* idPtr);
 static void __stdcall runtimeHookCharacterIdCopyPlayerToTemplate(int characterId, int playerIdx);
 static void __stdcall runtimeHookCharacterIdCopyTemplateToPlayer(int characterId, int playerIdx);
 static void __stdcall runtimeHookCharacterIdAnimateBlocks(void);
-static int __stdcall runtimeHookCharacterIdBlockPlayerCheck(PlayerMOB* player, int blockIdx);
+//static int __stdcall runtimeHookCharacterIdBlockPlayerCheck(PlayerMOB* player, int blockIdx);
 static int __stdcall runtimeHookCharacterIdSwitchBlockCheck(int blockId);
 static void __stdcall runtimeHookCharacterIdSwitchBlockTransform(int playerIdx, Block* block);
 
@@ -1203,7 +1203,7 @@ __declspec(naked) static void  __stdcall HOOK_0x9E1CA9() {
 static auto patch_animate_hook_0x9E1CA9 = PATCH(0x9E1CA9).CALL(HOOK_0x9E1CA9);
 
 // Check to allow player to pass through their own filter block type
-__declspec(naked) static void  __stdcall HOOK_0x9A3CC5() {
+/*__declspec(naked) static void  __stdcall HOOK_0x9A3CC5() {
     __asm {
         push ecx
         push edx
@@ -1216,7 +1216,8 @@ __declspec(naked) static void  __stdcall HOOK_0x9A3CC5() {
         ret
     }
 }
-static auto patch_block_passthrough_0x9A3CC5 = PATCH(0x9A3CC5).CALL(HOOK_0x9A3CC5).JMP(0x9A3DD2).NOP_PAD_TO_SIZE<269>();
+static auto patch_block_passthrough_0x9A3CC5 = PATCH(0x9A3CC5).CALL(HOOK_0x9A3CC5).JMP(0x9A3DD2).NOP_PAD_TO_SIZE<269>();*/
+static auto patch_block_passthrough_0x9A3CC5 = PATCH(0x9A3CC5).NOP_PAD_TO_SIZE<269>();
 
 // Check if this is a hittable switch block... 
 __declspec(naked) static void  __stdcall HOOK_0x9DA747() {
@@ -2261,7 +2262,7 @@ static void __stdcall runtimeHookCharacterIdAnimateBlocks(void)
     }
 }
 
-static int __stdcall runtimeHookCharacterIdBlockPlayerCheck(PlayerMOB* player, int blockIdx)
+/*static int __stdcall runtimeHookCharacterIdBlockPlayerCheck(PlayerMOB* player, int blockIdx)
 {
     short blockId = Block::GetRaw(blockIdx)->BlockType;
     short characterFilter = Blocks::GetBlockPlayerFilter(blockId);
@@ -2279,7 +2280,7 @@ static int __stdcall runtimeHookCharacterIdBlockPlayerCheck(PlayerMOB* player, i
     }
 
     return -1;
-}
+}*/
 
 static int __stdcall runtimeHookCharacterIdSwitchBlockCheck(int blockId)
 {

--- a/LunaDll/Misc/RuntimeHookComponents/RuntimeHookGeneral.cpp
+++ b/LunaDll/Misc/RuntimeHookComponents/RuntimeHookGeneral.cpp
@@ -1948,6 +1948,10 @@ void TrySkipPatch()
     PATCH(0x9E3D30).JMP(runtimeHookPSwitchStartRemoveBlockWrapper).NOP_PAD_TO_SIZE<110>().Apply();
     PATCH(0x9E3E54).JMP(runtimeHookPSwitchGetNewBlockAtEndWrapper).NOP_PAD_TO_SIZE<29>().Apply();
 
+    // Patch to handle blocks that allow players to pass through
+    // Moved from where the original code does it to allow player passthrough slopes
+    PATCH(0x9A16E8).JMP(runtimeHookBlockPlayerFilter).NOP_PAD_TO_SIZE<12>().Apply();
+
     // Patch to handle blocks that allow NPCs to pass through
     // Also handles collisionGroup for NPC-to-solid interactions now
     PATCH(0xA11B76).JMP(runtimeHookBlockNPCFilter).NOP_PAD_TO_SIZE<7>().Apply();


### PR DESCRIPTION
Moves the playerfilter hook from [where 1.3 does its player passthrough things](https://github.com/smbx/smbx-legacy-source/blob/master/modPlayer.bas#L2269) to where the [isHidden check](https://github.com/smbx/smbx-legacy-source/blob/master/modPlayer.bas#L2025) is, so that the actual collision doesn't even run. Probably also fixes some other, minor playerfilter things. Do let me know if there's any issues!