### PR TITLE
Fix NPC sections when they're out of bounds

### DIFF
--- a/LunaDll/LuaMain/LuaProxyFFI.cpp
+++ b/LunaDll/LuaMain/LuaProxyFFI.cpp
@@ -480,6 +480,18 @@ typedef struct ExtendedBlockFields_\
         }
     }
 
+    FFI_EXPORT(void) LunaLuaSetNPCSectionFix(bool enable)
+    {
+        if (enable)
+        {
+            gDisableNPCSectionFix.Apply();
+        }
+        else
+        {
+            gDisableNPCSectionFix.Unapply();
+        }
+    }
+
     FFI_EXPORT(void) LunaLuaSetFenceBugFix(bool enable) {
         if (enable) {
             for (int i = 0; gFenceFixes[i] != nullptr; i++) {

--- a/LunaDll/LuaMain/LunaLuaMain.cpp
+++ b/LunaDll/LuaMain/LunaLuaMain.cpp
@@ -124,6 +124,7 @@ bool CLunaLua::shutdown()
     gDisablePlayerDownwardClipFix.Apply();
     gDisableNPCDownwardClipFix.Apply();
     gDisableNPCDownwardClipFixSlope.Apply();
+    gDisableNPCSectionFix.Apply();
     for (int i = 0; gFenceFixes[i] != nullptr; i++) {
         gFenceFixes[i]->Apply();
     }

--- a/LunaDll/Misc/RuntimeHook.h
+++ b/LunaDll/Misc/RuntimeHook.h
@@ -38,6 +38,7 @@ void TrySkipPatch();
 extern AsmPatch<777> gDisablePlayerDownwardClipFix;
 extern AsmPatch<8> gDisableNPCDownwardClipFix;
 extern AsmPatch<167> gDisableNPCDownwardClipFixSlope;
+extern AsmPatch<502> gDisableNPCSectionFix;
 extern Patchable *gFenceFixes[];
 
 
@@ -462,6 +463,8 @@ void __stdcall runtimeHookCompareNPCWalkBlock();
 void __stdcall runtimeHookNPCWalkFixClearTemp();
 void __stdcall runtimeHookNPCWalkFixTempHitConditional();
 void __stdcall runtimeHookNPCWalkFixSlope();
+
+void __stdcall runtimeHookNPCSectionFix(short* npcIndex);
 
 void __stdcall runtimeHookAfterPSwitchBlocksReorderedWrapper(void);
 void __stdcall runtimeHookPSwitchStartRemoveBlockWrapper(void);

--- a/LunaDll/Misc/RuntimeHookComponents/RuntimeHookGeneral.cpp
+++ b/LunaDll/Misc/RuntimeHookComponents/RuntimeHookGeneral.cpp
@@ -1211,6 +1211,7 @@ static unsigned int __stdcall LatePatch(void)
 AsmPatch<777> gDisablePlayerDownwardClipFix = PATCH(0x9A3FD3).JMP(runtimeHookCompareWalkBlockForPlayerWrapper).NOP_PAD_TO_SIZE<777>();
 AsmPatch<8> gDisableNPCDownwardClipFix = PATCH(0xA16B82).JMP(runtimeHookCompareNPCWalkBlock).NOP_PAD_TO_SIZE<8>();
 AsmPatch<167> gDisableNPCDownwardClipFixSlope = PATCH(0xA13188).JMP(runtimeHookNPCWalkFixSlope).NOP_PAD_TO_SIZE<167>();
+AsmPatch<502> gDisableNPCSectionFix = PATCH(0xA3B680).JMP(&runtimeHookNPCSectionFix).NOP_PAD_TO_SIZE<502>();
 
 AsmPatch<11> gFenceFix_99933C = PATCH(0x99933C)
     .PUSH_EBX()
@@ -1942,6 +1943,9 @@ void TrySkipPatch()
     PATCH(0xA1BB3A).JMP(runtimeHookNPCWalkFixTempHitConditional).NOP_PAD_TO_SIZE<23>().Apply();
     // PATCH(0xA13188).JMP(runtimeHookNPCWalkFixSlope).NOP_PAD_TO_SIZE<167>()
     gDisableNPCDownwardClipFixSlope.Apply();
+
+    // Hook to fix an NPC's section property when it spawn out of bounds
+    gDisableNPCSectionFix.Apply();
 
     // Patch to handle block reorder after p-switch handling
     PATCH(0x9E441A).JMP(runtimeHookAfterPSwitchBlocksReorderedWrapper).NOP_PAD_TO_SIZE<242>().Apply();


### PR DESCRIPTION
Replaces the sub that handles section finding for NPC's. The NPC no longer needs to be _fully_ inside the section bounds, and if it isn't inside of any sections, it uses the closest one. The behaviour can be returned to the original via Misc.SetNPCSectionFix. Needs a different [ffi_misc.lua](https://cdn.discordapp.com/attachments/473616657408065536/1036287221583585310/ffi_misc.lua).