### PR TITLE
onPOW hooks

### DIFF
--- a/LunaDll/Misc/RuntimeHook.h
+++ b/LunaDll/Misc/RuntimeHook.h
@@ -353,6 +353,8 @@ void __stdcall runtimeHookPiranahDivByZero();
 void __stdcall runtimeHookHitBlock(unsigned short* blockIndex, short* fromUpSide, unsigned short* playerIdx);
 void __stdcall runtimeHookRemoveBlock(unsigned short* blockIndex, short* makeEffects);
 
+void __stdcall runtimeHookPOW();
+
 void __stdcall runtimeHookCollectNPC(short* playerIdx, short* npcIdx);
 
 void __stdcall runtimeHookLogCollideNpc(DWORD addr, short* pNpcIdx, CollidersType* pObjType, short* pObjIdx);

--- a/LunaDll/Misc/RuntimeHookComponents/RuntimeHookGeneral.cpp
+++ b/LunaDll/Misc/RuntimeHookComponents/RuntimeHookGeneral.cpp
@@ -1708,6 +1708,9 @@ void TrySkipPatch()
     PATCH(0x9DA620).JMP(&runtimeHookHitBlock).NOP_PAD_TO_SIZE<6>().Apply();
     PATCH(0x9E0D50).JMP(&runtimeHookRemoveBlock).NOP_PAD_TO_SIZE<6>().Apply();
 
+	// Hook POW
+	PATCH(0x9E4600).JMP(&runtimeHookPOW).NOP_PAD_TO_SIZE<6>().Apply();
+
     // Hook for onNPCCollect
     PATCH(0xA24CD0).JMP(&runtimeHookCollectNPC).NOP_PAD_TO_SIZE<6>().Apply();
 

--- a/LunaDll/Misc/RuntimeHookComponents/RuntimeHookGeneral.cpp
+++ b/LunaDll/Misc/RuntimeHookComponents/RuntimeHookGeneral.cpp
@@ -1708,8 +1708,8 @@ void TrySkipPatch()
     PATCH(0x9DA620).JMP(&runtimeHookHitBlock).NOP_PAD_TO_SIZE<6>().Apply();
     PATCH(0x9E0D50).JMP(&runtimeHookRemoveBlock).NOP_PAD_TO_SIZE<6>().Apply();
 
-	// Hook POW
-	PATCH(0x9E4600).JMP(&runtimeHookPOW).NOP_PAD_TO_SIZE<6>().Apply();
+    // Hook POW
+    PATCH(0x9E4600).JMP(&runtimeHookPOW).NOP_PAD_TO_SIZE<6>().Apply();
 
     // Hook for onNPCCollect
     PATCH(0xA24CD0).JMP(&runtimeHookCollectNPC).NOP_PAD_TO_SIZE<6>().Apply();

--- a/LunaDll/Misc/RuntimeHookComponents/RuntimeHookHooks.cpp
+++ b/LunaDll/Misc/RuntimeHookComponents/RuntimeHookHooks.cpp
@@ -2234,31 +2234,31 @@ void __stdcall runtimeHookRemoveBlock(unsigned short* blockIndex, short* makeEff
 
 static _declspec(naked) void __stdcall doPOW_OrigFunc()
 {
-	__asm {
-		PUSH EBP
-		MOV EBP, ESP
-		SUB ESP, 0x8
-		PUSH 0x9E4606
-		RET
-	}
+    __asm {
+        PUSH EBP
+        MOV EBP, ESP
+        SUB ESP, 0x8
+        PUSH 0x9E4606
+        RET
+    }
 }
 
 void __stdcall runtimeHookPOW()
 {
-	bool isCancelled = false;
+    bool isCancelled = false;
 
-	if (gLunaLua.isValid()) {
-		std::shared_ptr<Event> POWEvent = std::make_shared<Event>("onPOW", true);
-		POWEvent->setDirectEventName("onPOW");
-		POWEvent->setLoopable(false);
-		gLunaLua.callEvent(POWEvent);
-		isCancelled = POWEvent->native_cancelled();
-	}
+    if (gLunaLua.isValid()) {
+        std::shared_ptr<Event> POWEvent = std::make_shared<Event>("onPOW", true);
+        POWEvent->setDirectEventName("onPOW");
+        POWEvent->setLoopable(false);
+        gLunaLua.callEvent(POWEvent);
+        isCancelled = POWEvent->native_cancelled();
+    }
 
-	if (!isCancelled)
-	{
-		doPOW_OrigFunc();
-	}
+    if (!isCancelled)
+    {
+        doPOW_OrigFunc();
+    }
 }
 
 static void __stdcall runtimeHookColorSwitch(unsigned int color)

--- a/LunaDll/Misc/RuntimeHookComponents/RuntimeHookHooks.cpp
+++ b/LunaDll/Misc/RuntimeHookComponents/RuntimeHookHooks.cpp
@@ -2231,6 +2231,36 @@ void __stdcall runtimeHookRemoveBlock(unsigned short* blockIndex, short* makeEff
     }
 }
 
+
+static _declspec(naked) void __stdcall doPOW_OrigFunc()
+{
+	__asm {
+		PUSH EBP
+		MOV EBP, ESP
+		SUB ESP, 0x8
+		PUSH 0x9E4606
+		RET
+	}
+}
+
+void __stdcall runtimeHookPOW()
+{
+	bool isCancelled = false;
+
+	if (gLunaLua.isValid()) {
+		std::shared_ptr<Event> POWEvent = std::make_shared<Event>("onPOW", true);
+		POWEvent->setDirectEventName("onPOW");
+		POWEvent->setLoopable(false);
+		gLunaLua.callEvent(POWEvent);
+		isCancelled = POWEvent->native_cancelled();
+	}
+
+	if (!isCancelled)
+	{
+		doPOW_OrigFunc();
+	}
+}
+
 static void __stdcall runtimeHookColorSwitch(unsigned int color)
 {
     if (gLunaLua.isValid()) {


### PR DESCRIPTION
hooks for a simple onPOW event for the 1.3 POW code. this would require `"onPow",` to be added to the end of `Misc.LUNALUA_EVENTS` in main_events.lua. tested and all seems well. `Misc.doPOW()` works fine with it to boot.