### PR TITLE
Update Clang version in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Quick Overview
 
 Requirements to build LunaLua yourself
 ------
-Visual Studio 2015 (msvc140 compiler) or Clang
+Visual Studio 2015 (msvc140 compiler) or Clang 14
 
 Building LunaLua on Linux
 ------


### PR DESCRIPTION
Compiling SMBX2 fails with Clang 15 for some reason so Clang 14 should be used instead.