### PR TITLE
Added LunaLuaSetWindowScale and LunaLuaGetWindowSize

### DIFF
--- a/LunaDll/LuaMain/LuaProxyFFI.cpp
+++ b/LunaDll/LuaMain/LuaProxyFFI.cpp
@@ -12,6 +12,7 @@
 #include "../Rendering/LunaImage.h"
 #include "../Rendering/FrameCapture.h"
 #include "../Rendering/GL/GLTextureStore.h"
+#include "../Rendering/WindowSizeHandler.h"
 #include "../SMBXInternal/NPCs.h"
 #include "../SMBXInternal/Blocks.h"
 #include "../SMBXInternal/Layer.h"
@@ -806,6 +807,29 @@ typedef struct ExtendedBlockFields_\
         {
             ShowWindow(gMainWindowHwnd, SW_MAXIMIZE);
         }
+    }
+
+    FFI_EXPORT(void) LunaLuaSetWindowScale(double scale)
+    {
+        if (LunaLuaIsFullscreen()) return;
+        
+        gWindowSizeHandler.SetNewWindowScale(scale);
+        gWindowSizeHandler.Recalculate();
+    }
+
+    struct WindowSize
+    {
+        int w;
+        int h;
+    };
+    FFI_EXPORT(WindowSize) LunaLuaGetWindowSize()
+    {
+        int w;
+        int h;
+
+        gWindowSizeHandler.GetDPIScaledWindowSize(w, h);
+
+        return {w, h};
     }
 }
 

--- a/LunaDll/Rendering/WindowSizeHandler.h
+++ b/LunaDll/Rendering/WindowSizeHandler.h
@@ -55,6 +55,10 @@ public:
     // Copy whole state (thread safe)
     inline State getStateThreadSafe() { std::lock_guard<std::mutex> lock(mMutex); return mState; }
 
+    // Window size setting for FFI
+    void SetNewWindowScale(double scale);
+    void GetDPIScaledWindowSize(int& w, int& h);
+
     // Functions to set window (thread safe)
     void SetWindowSize(int w, int h);
     void Recalculate();


### PR DESCRIPTION
Adds two FFI functions:

- LunaLuaSetWindowScale, which sets the size of the window relative to the framebuffer's size. Perhaps useful for a menu option on its own, but can also be used for resizing the window after modifying the framebuffer size. The scale is applied together with the DPI scale, rather than overwriting it. It also won't do anything in fullscreen.
- LunaLuaGetWindowSize, which returns the current size of the window. It is relative to the DPI scale, so a 1200x900 window with a 1.5x DPI scale with still return 800x600.

If there are any issues with this implementation or a better way to go about things, let me know!

