### PR TITLE
Config to disable hardcoded NPC terminal velocity

### DIFF
--- a/LunaDll/Misc/RuntimeHook.h
+++ b/LunaDll/Misc/RuntimeHook.h
@@ -332,6 +332,7 @@ void __stdcall runtimeHookNPCVulnerabilityRaw(void);
 void __stdcall runtimeHookNPCSpinjumpSafeRaw(void);
 void __stdcall runtimeHookNPCNoWaterPhysicsRaw(void);
 void __stdcall runtimeHookNPCWaterSplashAnimRaw(short* effectID, Momentum* coor, float* effectFrame, short* npcID, short* showOnlyMask);
+void __stdcall runtimeHookNPCTerminalVelocityRaw(void);
 
 void __stdcall runtimeHookNPCHarmlessGrabRaw(void);
 void __stdcall runtimeHookNPCHarmlessThrownRaw(void);

--- a/LunaDll/Misc/RuntimeHookComponents/RuntimeHookGeneral.cpp
+++ b/LunaDll/Misc/RuntimeHookComponents/RuntimeHookGeneral.cpp
@@ -1673,6 +1673,8 @@ void TrySkipPatch()
     PATCH(0xA0B969).JMP(runtimeHookNPCHarmlessGrabRaw).NOP_PAD_TO_SIZE<183>().Apply();
     PATCH(0xA181AD).JMP(runtimeHookNPCHarmlessThrownRaw).NOP_PAD_TO_SIZE<6>().Apply();
 
+    PATCH(0xA10136).JMP(runtimeHookNPCTerminalVelocityRaw).NOP_PAD_TO_SIZE<58>().Apply();
+
     PATCH(0xA75079).JMP(runtimeHookCheckInputRaw).NOP_PAD_TO_SIZE<7>().Apply();
 
     // Hooks for per-npc noblockcollision

--- a/LunaDll/Misc/RuntimeHookComponents/RuntimeHookHooks.cpp
+++ b/LunaDll/Misc/RuntimeHookComponents/RuntimeHookHooks.cpp
@@ -1978,6 +1978,27 @@ _declspec(naked) void __stdcall runtimeHookNPCHarmlessThrownRaw()
     }
 }
 
+static void __stdcall runtimeHookNPCTerminalVelocity(NPCMOB* npc)
+{
+    // Reimplement the NPC terminal velocity behaviour
+    if (npc->momentum.speedY > 8 && !NPC::GetNoTerminalVelocity(npc->id))
+    {
+        npc->momentum.speedY = 8;
+    }
+}
+
+_declspec(naked) void __stdcall runtimeHookNPCTerminalVelocityRaw()
+{
+    __asm {
+        push esi // Arg #1 (pointer to NPC)
+
+        call runtimeHookNPCTerminalVelocity
+
+        push 0xA10170
+        ret
+    }
+}
+
 static void __stdcall runtimeHookCheckInput(int playerNum, int playerIdx, KeyMap* keymap)
 {
     // Test that player index is in range, and that it matches the true player number (ignore clones)

--- a/LunaDll/Misc/RuntimeHookComponents/RuntimeHookHooks.cpp
+++ b/LunaDll/Misc/RuntimeHookComponents/RuntimeHookHooks.cpp
@@ -1981,9 +1981,11 @@ _declspec(naked) void __stdcall runtimeHookNPCHarmlessThrownRaw()
 static void __stdcall runtimeHookNPCTerminalVelocity(NPCMOB* npc)
 {
     // Reimplement the NPC terminal velocity behaviour
-    if (npc->momentum.speedY > 8 && !NPC::GetNoTerminalVelocity(npc->id))
+    double terminalVelocity = NPC::GetTerminalVelocity(npc->id);
+
+    if ((terminalVelocity >= 0) && (npc->momentum.speedY > terminalVelocity))
     {
-        npc->momentum.speedY = 8;
+        npc->momentum.speedY = terminalVelocity;
     }
 }
 

--- a/LunaDll/SMBXInternal/NPCs.cpp
+++ b/LunaDll/SMBXInternal/NPCs.cpp
@@ -273,7 +273,7 @@ static int16_t npcprop_noshieldfireeffect[NPC::MAX_ID + 1] = { 0 };
 static int16_t npcprop_notcointransformable[NPC::MAX_ID + 1] = { 0 };
 static int16_t npcprop_staticdirection[NPC::MAX_ID + 1] = { 0 };
 static int16_t npcprop_luahandlesspeed[NPC::MAX_ID + 1] = { 0 };
-static int16_t npcprop_noterminalvelocity[NPC::MAX_ID + 1] = { 0 };
+static double npcprop_terminalvelocity[NPC::MAX_ID + 1] = { 0 };
 
 // Other NPC-related config data, not by ID
 static std::unordered_map<unsigned int, bool> npc_semisolidCollidingFlyTypeMap = { { 1, true } };
@@ -293,7 +293,7 @@ void NPC::InitProperties() {
         npcprop_notcointransformable[i] = 0;
         npcprop_staticdirection[i] = 0;
         npcprop_luahandlesspeed[i] = 0;
-        npcprop_noterminalvelocity[i] = 0;
+        npcprop_terminalvelocity[i] = 0;
     }
 
     // Set built-in spinjump safe IDs
@@ -500,9 +500,9 @@ void NPC::InitProperties() {
     npcprop_staticdirection[181] = -1;
     npcprop_staticdirection[212] = -1;
 
-    // Default noterminalvelocity NPCs
-    npcprop_noterminalvelocity[259] = -1;
-    npcprop_noterminalvelocity[260] = -1;
+    // Default terminal velocity values
+    npcprop_terminalvelocity[259] = -1;
+    npcprop_terminalvelocity[260] = -1;
 
     npc_semisolidCollidingFlyTypeMap.clear();
     npc_semisolidCollidingFlyTypeMap[1] = true;
@@ -564,9 +564,15 @@ bool NPC::GetLuaHandlesSpeed(int id) {
     return (npcprop_luahandlesspeed[id] != 0);
 }
 
-bool NPC::GetNoTerminalVelocity(int id) {
-    if ((id < 1) || (id > NPC::MAX_ID)) return false;
-    return (npcprop_noterminalvelocity[id] != 0);
+double NPC::GetTerminalVelocity(int id) {
+    if ((id < 1) || (id > NPC::MAX_ID) || (npcprop_terminalvelocity[id] == 0))
+    {
+        // Default terminal velocity
+        return 8;
+    }
+    
+    // Custom terminal velocity
+    return npcprop_terminalvelocity[id];
 }
 
 // Getter for address of NPC property arrays
@@ -616,9 +622,9 @@ uintptr_t NPC::GetPropertyTableAddress(const std::string& s)
     {
         return reinterpret_cast<uintptr_t>(npcprop_luahandlesspeed);
     }
-    else if (s == "noterminalvelocity")
+    else if (s == "terminalvelocity")
     {
-        return reinterpret_cast<uintptr_t>(npcprop_noterminalvelocity);
+        return reinterpret_cast<uintptr_t>(npcprop_terminalvelocity);
     }
     else
     {

--- a/LunaDll/SMBXInternal/NPCs.cpp
+++ b/LunaDll/SMBXInternal/NPCs.cpp
@@ -273,6 +273,7 @@ static int16_t npcprop_noshieldfireeffect[NPC::MAX_ID + 1] = { 0 };
 static int16_t npcprop_notcointransformable[NPC::MAX_ID + 1] = { 0 };
 static int16_t npcprop_staticdirection[NPC::MAX_ID + 1] = { 0 };
 static int16_t npcprop_luahandlesspeed[NPC::MAX_ID + 1] = { 0 };
+static int16_t npcprop_noterminalvelocity[NPC::MAX_ID + 1] = { 0 };
 
 // Other NPC-related config data, not by ID
 static std::unordered_map<unsigned int, bool> npc_semisolidCollidingFlyTypeMap = { { 1, true } };
@@ -292,6 +293,7 @@ void NPC::InitProperties() {
         npcprop_notcointransformable[i] = 0;
         npcprop_staticdirection[i] = 0;
         npcprop_luahandlesspeed[i] = 0;
+        npcprop_noterminalvelocity[i] = 0;
     }
 
     // Set built-in spinjump safe IDs
@@ -498,6 +500,10 @@ void NPC::InitProperties() {
     npcprop_staticdirection[181] = -1;
     npcprop_staticdirection[212] = -1;
 
+    // Default noterminalvelocity NPCs
+    npcprop_noterminalvelocity[259] = -1;
+    npcprop_noterminalvelocity[260] = -1;
+
     npc_semisolidCollidingFlyTypeMap.clear();
     npc_semisolidCollidingFlyTypeMap[1] = true;
 }
@@ -558,6 +564,11 @@ bool NPC::GetLuaHandlesSpeed(int id) {
     return (npcprop_luahandlesspeed[id] != 0);
 }
 
+bool NPC::GetNoTerminalVelocity(int id) {
+    if ((id < 1) || (id > NPC::MAX_ID)) return false;
+    return (npcprop_noterminalvelocity[id] != 0);
+}
+
 // Getter for address of NPC property arrays
 uintptr_t NPC::GetPropertyTableAddress(const std::string& s)
 {
@@ -604,6 +615,10 @@ uintptr_t NPC::GetPropertyTableAddress(const std::string& s)
     else if (s == "luahandlesspeed")
     {
         return reinterpret_cast<uintptr_t>(npcprop_luahandlesspeed);
+    }
+    else if (s == "noterminalvelocity")
+    {
+        return reinterpret_cast<uintptr_t>(npcprop_noterminalvelocity);
     }
     else
     {

--- a/LunaDll/SMBXInternal/NPCs.h
+++ b/LunaDll/SMBXInternal/NPCs.h
@@ -580,6 +580,7 @@ namespace NPC {
     bool GetNotCoinTransformable(int id);
     bool GetStaticDirection(int id);
     bool GetLuaHandlesSpeed(int id);
+    bool GetNoTerminalVelocity(int id);
 
     uintptr_t GetPropertyTableAddress(const std::string& s);
 

--- a/LunaDll/SMBXInternal/NPCs.h
+++ b/LunaDll/SMBXInternal/NPCs.h
@@ -580,7 +580,7 @@ namespace NPC {
     bool GetNotCoinTransformable(int id);
     bool GetStaticDirection(int id);
     bool GetLuaHandlesSpeed(int id);
-    bool GetNoTerminalVelocity(int id);
+    double GetTerminalVelocity(int id);
 
     uintptr_t GetPropertyTableAddress(const std::string& s);
 


### PR DESCRIPTION
Currently, all NPCs (except for 259 and 260) are hardcoded so that they cannot move more than 8 pixels down per frame, even if the nogravity config is set. This adds a config, "noterminalvelocity", which disables this behaviour.

Replaces [this line](https://github.com/smbx/smbx-legacy-source/blob/master/modNPC.bas#L1262) with a hook that checks the config. NPCs 259 and 260 have it set by default.

The hook does not push and pop any registers to save them. As far as I can tell this is safe here, but I could have missed something.