### PR TITLE
Collision matrix

### DIFF
--- a/LunaDll/CMakeLists.txt
+++ b/LunaDll/CMakeLists.txt
@@ -13,7 +13,6 @@ set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} /MANIFEST:NO")
 include(libs/PGE_File_Formats/pge_file_library.cmake)
 
 include_directories(
-    ${CMAKE_CURRENT_SOURCE_DIR}
     ${CMAKE_CURRENT_SOURCE_DIR}/libs/luabind-deboostified
     ${CMAKE_CURRENT_SOURCE_DIR}/libs/lua/include
     ${CMAKE_CURRENT_SOURCE_DIR}/libs/sdl/include

--- a/LunaDll/CMakeLists.txt
+++ b/LunaDll/CMakeLists.txt
@@ -168,6 +168,7 @@ set(LunaLua_Sources
     Minigames/GameboyRPG.cpp
     Minigames/Minigames.cpp
     Misc/AsyncHTTPClient.cpp
+    Misc/CollisionMatrix.cpp
     Misc/ErrorReporter.cpp
     Misc/FreeImageUtils/FreeImageData.cpp
     Misc/FreeImageUtils/FreeImageGifData.cpp

--- a/LunaDll/CMakeLists.txt
+++ b/LunaDll/CMakeLists.txt
@@ -189,6 +189,7 @@ set(LunaLua_Sources
     Misc/RuntimeHookComponents/RuntimeHookGeneral.cpp
     Misc/RuntimeHookComponents/RuntimeHookHooks.cpp
     Misc/RuntimeHookComponents/RuntimeHookNpcHarm.cpp
+    Misc/RuntimeHookComponents/RuntimeHookNPCTransform.cpp
     Misc/RuntimeHookComponents/RuntimeHookPublicFunctions.cpp
     Misc/RuntimeHook.cpp
     Misc/RuntimeHookManagers/LevelHUDController.cpp

--- a/LunaDll/CMakeLists.txt
+++ b/LunaDll/CMakeLists.txt
@@ -173,6 +173,7 @@ set(LunaLua_Sources
     Misc/FreeImageUtils/FreeImageGifData.cpp
     Misc/FreeImageUtils/FreeImageHelper.cpp
     Misc/FreeImageUtils/FreeImageInit.cpp
+    Misc/Gameover.cpp
     Misc/Gui/GuiCrashNotify.cpp
     Misc/Gui/RichTextDialog.cpp
     Misc/LoadScreen.cpp

--- a/LunaDll/CMakeLists.txt
+++ b/LunaDll/CMakeLists.txt
@@ -184,6 +184,7 @@ set(LunaLua_Sources
     Misc/Playground.cpp
     Misc/ResourceFileMapper.cpp
     Misc/RuntimeHookComponents/RuntimeHookCharacterId.cpp
+    Misc/RuntimeHookComponents/RuntimeHookDefines.cpp
     Misc/RuntimeHookComponents/RuntimeHookFixups.cpp
     Misc/RuntimeHookComponents/RuntimeHookGeneral.cpp
     Misc/RuntimeHookComponents/RuntimeHookHooks.cpp

--- a/LunaDll/FileManager/config_manager.cpp
+++ b/LunaDll/FileManager/config_manager.cpp
@@ -572,7 +572,7 @@ static void make_list_defaults_numeric_list(nlohmann::json& dst, nlohmann::json&
         nlohmann::json entry = nlohmann::json();
         entry["k"] = kvp.key();
         if (kvp.value().is_object() || kvp.value().is_array()) {
-            nlohmann::json& childObj = nlohmann::json();
+            nlohmann::json&& childObj = nlohmann::json();
             make_list_defaults_numeric_list(childObj, kvp.value());
             entry["v"] = childObj;
         }

--- a/LunaDll/GlobalFuncs.cpp
+++ b/LunaDll/GlobalFuncs.cpp
@@ -1037,19 +1037,3 @@ void HandleEventsWhileLoading()
         lastTime = thisTime;
     }
 }
-
-// https://en.wikipedia.org/wiki/Fowler%E2%80%93Noll%E2%80%93Vo_hash_function#FNV-1_hash
-std::size_t hashString(char const* string) {
-    std::size_t hash = 0x811c9dc5;
-
-    for(; *string != '\0'; string++) {
-        hash = (hash * 0x01000193) ^ ((unsigned char) *string);
-    }
-
-    return hash;
-}
-
-// Uses boost's implementation of boost::hash_combine
-std::size_t combineHash(std::size_t firstHash, std::size_t secondHash) {
-    return secondHash + 0x9e3779b9 + (firstHash << 6) + (firstHash >> 2);
-}

--- a/LunaDll/GlobalFuncs.cpp
+++ b/LunaDll/GlobalFuncs.cpp
@@ -1037,3 +1037,19 @@ void HandleEventsWhileLoading()
         lastTime = thisTime;
     }
 }
+
+// https://en.wikipedia.org/wiki/Fowler%E2%80%93Noll%E2%80%93Vo_hash_function#FNV-1_hash
+std::size_t hashString(char const* string) {
+    std::size_t hash = 0x811c9dc5;
+
+    for(; *string != '\0'; string++) {
+        hash = (hash * 0x01000193) ^ ((unsigned char) *string);
+    }
+
+    return hash;
+}
+
+// Uses boost's implementation of boost::hash_combine
+std::size_t combineHash(std::size_t firstHash, std::size_t secondHash) {
+    return secondHash + 0x9e3779b9 + (firstHash << 6) + (firstHash >> 2);
+}

--- a/LunaDll/GlobalFuncs.h
+++ b/LunaDll/GlobalFuncs.h
@@ -276,14 +276,4 @@ constexpr std::uint32_t DoubleMostSignificantDWord(double d) {
 }
 #endif
 
-// Hash a null-terminated c string without having to create a std::string
-std::size_t hashString(char const* string);
-
-// Combine two hash values together
-std::size_t combineHash(std::size_t firstHash, std::size_t secondHash);
-
-// Stringify int literals
-#define STRINGIFY(x) STRINGIFY2(x)
-#define STRINGIFY2(x) #x
-
 #endif

--- a/LunaDll/GlobalFuncs.h
+++ b/LunaDll/GlobalFuncs.h
@@ -276,4 +276,14 @@ constexpr std::uint32_t DoubleMostSignificantDWord(double d) {
 }
 #endif
 
+// Hash a null-terminated c string without having to create a std::string
+std::size_t hashString(char const* string);
+
+// Combine two hash values together
+std::size_t combineHash(std::size_t firstHash, std::size_t secondHash);
+
+// Stringify int literals
+#define STRINGIFY(x) STRINGIFY2(x)
+#define STRINGIFY2(x) #x
+
 #endif

--- a/LunaDll/LuaMain/LuaProxyFFI.cpp
+++ b/LunaDll/LuaMain/LuaProxyFFI.cpp
@@ -431,7 +431,7 @@ extern "C" {
 typedef struct ExtendedNPCFields_\
 {\
     bool noblockcollision;\
-    char collisionGroup[" STRINGIFY(COLLISION_GROUP_STRING_LENGTH) "];\
+    unsigned int collisionGroup;\
 } ExtendedNPCFields;";
     }
 
@@ -449,23 +449,33 @@ typedef struct ExtendedBlockFields_\
     double layerSpeedY;\
     double extraSpeedX;\
     double extraSpeedY;\
-    char collisionGroup[" STRINGIFY(COLLISION_GROUP_STRING_LENGTH) "];\
+    unsigned int collisionGroup;\
 } ExtendedBlockFields;";
     }
 
-    FFI_EXPORT(int) LunaLuaGetCollisionGroupStringLength()
+    FFI_EXPORT(unsigned int) LunaLuaCollisionMatrixAllocateIndex()
     {
-        return collisionGroupStringLength;
+        return gCollisionMatrix.allocateIndex();
     }
 
-    FFI_EXPORT(void) LunaLuaGlobalCollisionMatrixSetGroupsCollide(char const* first, char const* second, bool collide)
+    FFI_EXPORT(void) LunaLuaCollisionMatrixIncrementReferenceCount(unsigned int group)
     {
-        gCollisionMatrix.setGroupsCollide(first, second, collide);
+        gCollisionMatrix.incrementReferenceCount(group);
     }
 
-    FFI_EXPORT(bool) LunaLuaGlobalCollisionMatrixGetGroupsCollide(char const* first, char const* second) 
+    FFI_EXPORT(void) LunaLuaCollisionMatrixDecrementReferenceCount(unsigned int group)
     {
-        return gCollisionMatrix.getGroupsCollide(first, second);
+        gCollisionMatrix.decrementReferenceCount(group);
+    }
+
+    FFI_EXPORT(void) LunaLuaGlobalCollisionMatrixSetIndicesCollide(unsigned int first, unsigned int second, bool collide)
+    {
+        gCollisionMatrix.setIndicesCollide(first, second, collide);
+    }
+
+    FFI_EXPORT(bool) LunaLuaGlobalCollisionMatrixGetIndicesCollide(unsigned int first, unsigned int second) 
+    {
+        return gCollisionMatrix.getIndicesCollide(first, second);
     }
 
     FFI_EXPORT(void) LunaLuaSetPlayerFilterBounceFix(bool enable)

--- a/LunaDll/LuaMain/LuaProxyFFI.cpp
+++ b/LunaDll/LuaMain/LuaProxyFFI.cpp
@@ -28,6 +28,7 @@
 
 #include "../Rendering/GL/GLEngine.h"
 #include "../Rendering/GL/GLEngineProxy.h"
+#include "Misc/CollisionMatrix.h"
 
 #define FFI_EXPORT(sig) __declspec(dllexport) sig __cdecl
 
@@ -430,7 +431,7 @@ extern "C" {
 typedef struct ExtendedNPCFields_\
 {\
     bool noblockcollision;\
-    char collisionGroup[32];\
+    char collisionGroup[" STRINGIFY(COLLISION_GROUP_STRING_LENGTH) "];\
 } ExtendedNPCFields;";
     }
 
@@ -448,13 +449,23 @@ typedef struct ExtendedBlockFields_\
     double layerSpeedY;\
     double extraSpeedX;\
     double extraSpeedY;\
-    char collisionGroup[32];\
+    char collisionGroup[" STRINGIFY(COLLISION_GROUP_STRING_LENGTH) "];\
 } ExtendedBlockFields;";
     }
 
     FFI_EXPORT(int) LunaLuaGetCollisionGroupStringLength()
     {
-        return 32;
+        return collisionGroupStringLength;
+    }
+
+    FFI_EXPORT(void) LunaLuaGlobalCollisionMatrixSetGroupsCollide(char const* first, char const* second, bool collide)
+    {
+        gCollisionMatrix.setGroupsCollide(first, second, collide);
+    }
+
+    FFI_EXPORT(bool) LunaLuaGlobalCollisionMatrixGetGroupsCollide(char const* first, char const* second) 
+    {
+        gCollisionMatrix.getGroupsCollide(first, second);
     }
 
     FFI_EXPORT(void) LunaLuaSetPlayerFilterBounceFix(bool enable)

--- a/LunaDll/LuaMain/LuaProxyFFI.cpp
+++ b/LunaDll/LuaMain/LuaProxyFFI.cpp
@@ -465,7 +465,7 @@ typedef struct ExtendedBlockFields_\
 
     FFI_EXPORT(bool) LunaLuaGlobalCollisionMatrixGetGroupsCollide(char const* first, char const* second) 
     {
-        gCollisionMatrix.getGroupsCollide(first, second);
+        return gCollisionMatrix.getGroupsCollide(first, second);
     }
 
     FFI_EXPORT(void) LunaLuaSetPlayerFilterBounceFix(bool enable)

--- a/LunaDll/LuaMain/LuaProxyFFI.cpp
+++ b/LunaDll/LuaMain/LuaProxyFFI.cpp
@@ -28,7 +28,7 @@
 
 #include "../Rendering/GL/GLEngine.h"
 #include "../Rendering/GL/GLEngineProxy.h"
-#include "Misc/CollisionMatrix.h"
+#include "../Misc/CollisionMatrix.h"
 
 #define FFI_EXPORT(sig) __declspec(dllexport) sig __cdecl
 

--- a/LunaDll/LuaMain/LunaLuaMain.cpp
+++ b/LunaDll/LuaMain/LunaLuaMain.cpp
@@ -30,6 +30,7 @@
 #include "../Misc/LoadScreen.h"
 
 #include "LunaPathValidator.h"
+#include "Misc/CollisionMatrix.h"
 
 /*static*/ DWORD CLunaFFILock::currentLockTlsIdx = TlsAlloc();
 
@@ -129,6 +130,7 @@ bool CLunaLua::shutdown()
     for (int i = 0; gFenceFixes[i] != nullptr; i++) {
         gFenceFixes[i]->Apply();
     }
+    gCollisionMatrix.clear();
 
     // Request cached images/sounds/files be held onto for now
     LunaImage::holdCachedImages(m_type == LUNALUA_WORLD);

--- a/LunaDll/LuaMain/LunaLuaMain.cpp
+++ b/LunaDll/LuaMain/LunaLuaMain.cpp
@@ -30,7 +30,7 @@
 #include "../Misc/LoadScreen.h"
 
 #include "LunaPathValidator.h"
-#include "Misc/CollisionMatrix.h"
+#include "../Misc/CollisionMatrix.h"
 
 /*static*/ DWORD CLunaFFILock::currentLockTlsIdx = TlsAlloc();
 

--- a/LunaDll/LunaDll.vcxproj
+++ b/LunaDll/LunaDll.vcxproj
@@ -147,6 +147,7 @@
     <ClInclude Include="libs\Utils\vptrlist.h" />
     <ClInclude Include="LuaMain\LuaProxyFFIGraphics.h" />
     <ClInclude Include="LuaMain\LunaPathValidator.h" />
+    <ClInclude Include="Misc\CollisionMatrix.h" />
     <ClInclude Include="Misc\LoadScreen.h" />
     <ClInclude Include="Misc\NpcIdExtender.h" />
     <ClInclude Include="Misc\ResourceFileMapper.h" />
@@ -338,6 +339,7 @@
     <ClCompile Include="LuaMain\LuaProxyComponent\LuaProxyFileFormats.cpp" />
     <ClCompile Include="LuaMain\LuaProxyFFIGraphics.cpp" />
     <ClCompile Include="LuaMain\LunaPathValidator.cpp" />
+    <ClCompile Include="Misc\CollisionMatrix.cpp" />
     <ClCompile Include="Misc\LoadScreen.cpp" />
     <ClCompile Include="Misc\NpcIdExtender.cpp" />
     <ClCompile Include="Misc\ResourceFileMapper.cpp" />

--- a/LunaDll/LunaDll.vcxproj.filters
+++ b/LunaDll/LunaDll.vcxproj.filters
@@ -218,6 +218,9 @@
     <ClInclude Include="Misc\RuntimeHook.h">
       <Filter>Misc</Filter>
     </ClInclude>
+    <ClInclude Include="Misc\CollisionMatrix.h">
+      <Filter>Misc</Filter>
+    </ClInclude>
     <ClInclude Include="SMBXInternal\NPCs.h">
       <Filter>SMBXInternal</Filter>
     </ClInclude>
@@ -832,6 +835,9 @@
       <Filter>Minigames\CGUI</Filter>
     </ClCompile>
     <ClCompile Include="Misc\MiscFuncs.cpp">
+      <Filter>Misc</Filter>
+    </ClCompile>
+    <ClCompile Include="Misc\CollisionMatrix.cpp">
       <Filter>Misc</Filter>
     </ClCompile>
     <ClCompile Include="Misc\RuntimeHook.cpp">

--- a/LunaDll/Misc/CollisionMatrix.cpp
+++ b/LunaDll/Misc/CollisionMatrix.cpp
@@ -31,7 +31,7 @@ bool CollisionMatrix::getGroupsCollide(char const firstGroup[collisionGroupStrin
     auto search = matrix.find(pair);
 
     // If there's already a value corresponding to the pair in our hashmap, return it.
-    if (search == matrix.end()) {
+    if (search != matrix.end()) {
         return search->second;
     }
 

--- a/LunaDll/Misc/CollisionMatrix.cpp
+++ b/LunaDll/Misc/CollisionMatrix.cpp
@@ -1,49 +1,139 @@
 #include "CollisionMatrix.h"
-#include <windows.h>
-#include <cstring>
-#include "../GlobalFuncs.h"
 #include <algorithm>
+#include <memory>
+#include <queue>
+#include <string>
+#include <tuple>
+#include "../../Globals.h"
 
-CollisionMatrix gCollisionMatrix;
+CollisionMatrix gCollisionMatrix([] (unsigned int i, unsigned int j) { return i == 0 || i != j; }, "onGroupDeallocationInternal");
 
-GroupPair::GroupPair(char const first[collisionGroupStringLength], char const second[collisionGroupStringLength]) {
+CollisionMatrix::CollisionMatrix(fun_type f, char const* ev) :
+    matrix(),
+    deallocated_groups(),
+    next_group(1),
+    reference_count(),
+    default_behavior(f),
+    deallocation_event_name(ev)
+{}
 
-    if (std::strncmp(first, second, collisionGroupStringLength) < 0) {
-        std::strncpy(this->firstGroup, first, collisionGroupStringLength);
-        std::strncpy(this->secondGroup, second, collisionGroupStringLength);
+void CollisionMatrix::clear() {
+    // Clear collision matrix
+    matrix.clear();
+    
+    // Clear deallocated group indices set
+    deallocated_groups = queue_type();
+
+    // Default group index (0) is allocated by default so the next one to be allocated is group index 1
+    next_group = 1;
+
+    // Clear reference count vector
+    reference_count.clear();
+}
+
+unsigned int CollisionMatrix::allocateIndex() {
+    unsigned int new_group;
+
+    if (deallocated_groups.empty()) { // If there's no available deallocated group index, create a new one.
+        new_group = next_group;
+        next_group++;
+
+        reference_count.push_back(0u);
+    } else { // Otherwise, take one from the set.
+        new_group = deallocated_groups.top();
+        deallocated_groups.pop();
+
+        // No need to set the reference count to 0 since a deallocated group index always has a reference count of 0.
+    }
+
+    return new_group;
+}
+
+void CollisionMatrix::incrementReferenceCount(unsigned int group) {
+    if (group != 0) { // We don't use reference counting for the default group index
+        reference_count[group - 1]++;
+    }
+}
+
+void CollisionMatrix::decrementReferenceCount(unsigned int group) {
+    if (group != 0) { // We don't use reference counting for the default group index
+        reference_count[group - 1]--;
+
+        if (reference_count[group - 1] == 0) {
+            deallocateGroup(group);
+        }
+    }
+}
+
+
+bool CollisionMatrix::getIndicesCollide(unsigned int i, unsigned int j) {
+    unsigned int min, max;
+    std::tie(min, max) = std::minmax(i, j);
+
+    // If matrix[max] contains min, returns !default_behavior(min, max). Otherwise, return default_behavior(min, max).
+    return (max < matrix.size() && matrix[max].count(min) == 1) != default_behavior(min, max);
+}
+
+void CollisionMatrix::setIndicesCollide(unsigned int i, unsigned int j, bool collide) {
+    unsigned int min, max;
+    std::tie(min, max) = std::minmax(i, j);
+
+    if (max >= matrix.size()) { // If the matrix is too small to contain (min, max)
+        if (collide != default_behavior(min, max)) { // If element (min, max) of the matrix is modified
+            // Resize the matrix
+            matrix.resize(max + 1);
+
+            // Insert (min, max) in the matrix
+            matrix[max].insert(min);
+
+            // Update reference counts
+            incrementReferenceCount(min);
+            incrementReferenceCount(max);
+        }
     } else {
-        std::strncpy(this->firstGroup, second, collisionGroupStringLength);
-        std::strncpy(this->secondGroup, first, collisionGroupStringLength);
+        auto current_collide_iter = matrix[max].find(min); // Search collision group index min in set max
+        bool contains = current_collide_iter != matrix[max].end(); // Check whether the previous search has succeeded or not
+        bool default_collide = default_behavior(min, max); // Get default behavior
+
+        if (contains && (collide == default_collide)) { // If we have to remove collision group index min from set max
+            // Remove it
+            matrix[max].erase(current_collide_iter);
+
+            // Update reference counts
+            decrementReferenceCount(min);
+            decrementReferenceCount(max);
+
+            // Cleanup collision matrix
+            cleanupMatrix();
+        } else if (!contains && (collide != default_collide)) { // If we have to insert collision group index min in set max
+            // Insert it
+            matrix[max].insert(min);
+
+            // Update reference counts
+            incrementReferenceCount(min);
+            incrementReferenceCount(max);
+        }
     }
 }
 
-std::size_t std::hash<GroupPair>::operator()(GroupPair const& value) const {
-    return combineHash(hashString(value.first()), hashString(value.second()));
+void CollisionMatrix::cleanupMatrix() {
+    // Search last nonempty group index
+    unsigned int last_nonempty_group = matrix.size() - 1;
+    for (; last_nonempty_group < matrix.size() && matrix[last_nonempty_group].empty(); last_nonempty_group--) {}
+
+    // Resize collision matrix
+    matrix.resize(last_nonempty_group + 1);
 }
 
-bool GroupPair::operator==(GroupPair const& that) const {
-    return std::strncmp(this->firstGroup, that.firstGroup, collisionGroupStringLength) == 0
-        && std::strncmp(this->secondGroup, that.secondGroup, collisionGroupStringLength) == 0;
-}
-
-bool CollisionMatrix::getGroupsCollide(char const firstGroup[collisionGroupStringLength], char const secondGroup[collisionGroupStringLength]) {
-    GroupPair pair(firstGroup, secondGroup);
-    auto search = matrix.find(pair);
-
-    // If there's already a value corresponding to the pair in our hashmap, return it.
-    if (search != matrix.end()) {
-        return search->second;
+void CollisionMatrix::deallocateGroup(unsigned int group) {
+    // Call lunalua event
+    if (gLunaLua.isValid()) {
+        std::shared_ptr<Event> deallocation_event = std::make_shared<Event>(deallocation_event_name, false);
+        deallocation_event->setDirectEventName(deallocation_event_name);
+        deallocation_event->setLoopable(false);
+        gLunaLua.callEvent(deallocation_event, group);
     }
 
-    // Otherwise, fallback to the default behavior and cache the result.
-    bool collide = firstGroup[0] == '\0' || strncmp(firstGroup, secondGroup, collisionGroupStringLength) != 0;
-    matrix[pair] = collide;
-
-    return collide;
-}
-
-void CollisionMatrix::setGroupsCollide(char const firstGroup[collisionGroupStringLength], char const secondGroup[collisionGroupStringLength], bool collide) {
-    GroupPair pair(firstGroup, secondGroup);
-
-    matrix[pair] = collide;
+    // Put group index in deallocated group indices
+    deallocated_groups.push(group);
 }

--- a/LunaDll/Misc/CollisionMatrix.cpp
+++ b/LunaDll/Misc/CollisionMatrix.cpp
@@ -1,7 +1,7 @@
 #include "CollisionMatrix.h"
 #include <windows.h>
 #include <cstring>
-#include "GlobalFuncs.h"
+#include "../GlobalFuncs.h"
 #include <algorithm>
 
 CollisionMatrix gCollisionMatrix;

--- a/LunaDll/Misc/CollisionMatrix.cpp
+++ b/LunaDll/Misc/CollisionMatrix.cpp
@@ -1,0 +1,49 @@
+#include "CollisionMatrix.h"
+#include <windows.h>
+#include <cstring>
+#include "GlobalFuncs.h"
+#include <algorithm>
+
+CollisionMatrix gCollisionMatrix;
+
+GroupPair::GroupPair(char const first[collisionGroupStringLength], char const second[collisionGroupStringLength]) {
+
+    if (std::strncmp(first, second, collisionGroupStringLength) < 0) {
+        std::strncpy(this->firstGroup, first, collisionGroupStringLength);
+        std::strncpy(this->secondGroup, second, collisionGroupStringLength);
+    } else {
+        std::strncpy(this->firstGroup, second, collisionGroupStringLength);
+        std::strncpy(this->secondGroup, first, collisionGroupStringLength);
+    }
+}
+
+std::size_t std::hash<GroupPair>::operator()(GroupPair const& value) const {
+    return combineHash(hashString(value.first()), hashString(value.second()));
+}
+
+bool GroupPair::operator==(GroupPair const& that) const {
+    return std::strncmp(this->firstGroup, that.firstGroup, collisionGroupStringLength) == 0
+        && std::strncmp(this->secondGroup, that.secondGroup, collisionGroupStringLength) == 0;
+}
+
+bool CollisionMatrix::getGroupsCollide(char const firstGroup[collisionGroupStringLength], char const secondGroup[collisionGroupStringLength]) {
+    GroupPair pair(firstGroup, secondGroup);
+    auto search = matrix.find(pair);
+
+    // If there's already a value corresponding to the pair in our hashmap, return it.
+    if (search == matrix.end()) {
+        return search->second;
+    }
+
+    // Otherwise, fallback to the default behavior and cache the result.
+    bool collide = firstGroup[0] == '\0' || strncmp(firstGroup, secondGroup, collisionGroupStringLength) != 0;
+    matrix[pair] = collide;
+
+    return collide;
+}
+
+void CollisionMatrix::setGroupsCollide(char const firstGroup[collisionGroupStringLength], char const secondGroup[collisionGroupStringLength], bool collide) {
+    GroupPair pair(firstGroup, secondGroup);
+
+    matrix[pair] = collide;
+}

--- a/LunaDll/Misc/CollisionMatrix.cpp
+++ b/LunaDll/Misc/CollisionMatrix.cpp
@@ -6,14 +6,13 @@
 #include <tuple>
 #include "../../Globals.h"
 
-CollisionMatrix gCollisionMatrix([] (unsigned int i, unsigned int j) { return i == 0 || i != j; }, "onGroupDeallocationInternal");
+CollisionMatrix gCollisionMatrix("onGroupDeallocationInternal");
 
-CollisionMatrix::CollisionMatrix(fun_type f, char const* ev) :
+CollisionMatrix::CollisionMatrix(char const* ev) :
     matrix(),
     deallocated_groups(),
     next_group(1),
     reference_count(),
-    default_behavior(f),
     deallocation_event_name(ev)
 {}
 
@@ -71,7 +70,7 @@ bool CollisionMatrix::getIndicesCollide(unsigned int i, unsigned int j) {
     std::tie(min, max) = std::minmax(i, j);
 
     // If matrix[max] contains min, returns !default_behavior(min, max). Otherwise, return default_behavior(min, max).
-    return (max < matrix.size() && matrix[max].count(min) == 1) != default_behavior(min, max);
+    return (max < matrix.size() && matrix[max].count(min) == 1) != defaultBehavior(min, max);
 }
 
 void CollisionMatrix::setIndicesCollide(unsigned int i, unsigned int j, bool collide) {
@@ -79,7 +78,7 @@ void CollisionMatrix::setIndicesCollide(unsigned int i, unsigned int j, bool col
     std::tie(min, max) = std::minmax(i, j);
 
     if (max >= matrix.size()) { // If the matrix is too small to contain (min, max)
-        if (collide != default_behavior(min, max)) { // If element (min, max) of the matrix is modified
+        if (collide != defaultBehavior(min, max)) { // If element (min, max) of the matrix is modified
             // Resize the matrix
             matrix.resize(max + 1);
 
@@ -93,7 +92,7 @@ void CollisionMatrix::setIndicesCollide(unsigned int i, unsigned int j, bool col
     } else {
         auto current_collide_iter = matrix[max].find(min); // Search collision group index min in set max
         bool contains = current_collide_iter != matrix[max].end(); // Check whether the previous search has succeeded or not
-        bool default_collide = default_behavior(min, max); // Get default behavior
+        bool default_collide = defaultBehavior(min, max); // Get default behavior
 
         if (contains && (collide == default_collide)) { // If we have to remove collision group index min from set max
             // Remove it
@@ -136,4 +135,8 @@ void CollisionMatrix::deallocateGroup(unsigned int group) {
 
     // Put group index in deallocated group indices
     deallocated_groups.push(group);
+}
+
+bool CollisionMatrix::defaultBehavior(unsigned int i, unsigned int j) const {
+    return i == 0 || i != j;
 }

--- a/LunaDll/Misc/CollisionMatrix.h
+++ b/LunaDll/Misc/CollisionMatrix.h
@@ -1,0 +1,54 @@
+#ifndef CollisionMatrix_hhh
+#define CollisionMatrix_hhh
+
+#include <unordered_map>
+
+#define COLLISION_GROUP_STRING_LENGTH 32
+constexpr std::size_t collisionGroupStringLength = COLLISION_GROUP_STRING_LENGTH;
+
+class GroupPair {
+    char firstGroup[collisionGroupStringLength];
+    char secondGroup[collisionGroupStringLength];
+
+public:
+    GroupPair(char const first[collisionGroupStringLength], char const second[collisionGroupStringLength]);
+
+    constexpr char const* first() const {
+        return firstGroup;
+    }
+
+    constexpr char const* second() const {
+        return secondGroup;
+    }
+
+    bool operator==(GroupPair const& that) const;
+    
+    inline bool operator!=(GroupPair const& that) const {
+        return !(*this == that);
+    }
+};
+
+namespace std {
+    template<>
+    struct hash<GroupPair> {
+        std::size_t operator()(GroupPair const& value) const;
+    };
+}
+
+class CollisionMatrix {
+    std::unordered_map<GroupPair, bool> matrix;
+
+public:
+    CollisionMatrix() = default;
+
+    inline void clear() {
+        matrix.clear();
+    }
+
+    bool getGroupsCollide(char const firstGroup[collisionGroupStringLength], char const secondGroup[collisionGroupStringLength]);
+    void setGroupsCollide(char const firstGroup[collisionGroupStringLength], char const secondGroup[collisionGroupStringLength], bool collide);
+};
+
+extern CollisionMatrix gCollisionMatrix;
+
+#endif

--- a/LunaDll/Misc/CollisionMatrix.h
+++ b/LunaDll/Misc/CollisionMatrix.h
@@ -16,7 +16,7 @@ class CollisionMatrix {
 
     std::vector<unsigned int> reference_count; // How many references to the group exist. Index 0 corresponds to group 1
 
-    bool (*default_behavior)(unsigned int i, unsigned int j); // The default behavior of the collision matrix
+    fun_type default_behavior; // The default behavior of the collision matrix
 
     char const* deallocation_event_name; // The lunalua event which is called whenever a group is deallocated
     

--- a/LunaDll/Misc/CollisionMatrix.h
+++ b/LunaDll/Misc/CollisionMatrix.h
@@ -6,7 +6,6 @@
 #include <unordered_set>
 
 class CollisionMatrix {
-    using fun_type = bool (*)(unsigned int i, unsigned int j);
     using queue_type = std::priority_queue<unsigned int, std::priority_queue<unsigned int>::container_type, std::greater<unsigned int>>;
 
     std::vector<std::unordered_set<unsigned int>> matrix; // The collision matrix itself. matrix[j].count(i) == 1 if getGroupsCollide(i, j) != default_behavior(i, j).
@@ -16,16 +15,18 @@ class CollisionMatrix {
 
     std::vector<unsigned int> reference_count; // How many references to the group exist. Index 0 corresponds to group 1
 
-    fun_type default_behavior; // The default behavior of the collision matrix
 
     char const* deallocation_event_name; // The lunalua event which is called whenever a group is deallocated
     
     void cleanupMatrix(); // Removes all trailing empty sets from the collision matrix
     void deallocateGroup(unsigned int group); // Deallocates a collision group
 
+protected:
+    bool defaultBehavior(unsigned int i, unsigned int j) const; // The default behavior of the collision matrix
+
 public:
     CollisionMatrix() = delete;
-    CollisionMatrix(fun_type default_behavior, char const* deallocation_event_name);
+    CollisionMatrix(char const* deallocation_event_name);
 
     void clear(); // Resets this collision matrix
     unsigned int allocateIndex(); // Allocates a new collision group index

--- a/LunaDll/Misc/RuntimeHookComponents/RuntimeHookHooks.cpp
+++ b/LunaDll/Misc/RuntimeHookComponents/RuntimeHookHooks.cpp
@@ -1,5 +1,5 @@
 #include <comutil.h>
-#include "Misc/CollisionMatrix.h"
+#include "../../Misc/CollisionMatrix.h"
 #include "string.h"
 #include "../../Globals.h"
 #include "../RuntimeHook.h"

--- a/LunaDll/Misc/RuntimeHookComponents/RuntimeHookHooks.cpp
+++ b/LunaDll/Misc/RuntimeHookComponents/RuntimeHookHooks.cpp
@@ -1,4 +1,5 @@
 #include <comutil.h>
+#include "Misc/CollisionMatrix.h"
 #include "string.h"
 #include "../../Globals.h"
 #include "../RuntimeHook.h"
@@ -3632,22 +3633,19 @@ static unsigned int __stdcall runtimeHookBlockNPCFilterInternal(unsigned int hit
 
         ExtendedNPCFields* ext = NPC::GetRawExtended(npcIdx);
 
-        if (ext->collisionGroup[0] != 0) // Collision group string isn't empty
+        if (block->OwnerNPCID != 0) // Belongs to an NPC
         {
-            if (block->OwnerNPCID != 0) // Belongs to an NPC
-            {
-                ExtendedNPCFields* ownerExt = NPC::GetRawExtended(block->OwnerNPCIdx);
+            ExtendedNPCFields* ownerExt = NPC::GetRawExtended(block->OwnerNPCIdx);
 
-                if (strcmp(ext->collisionGroup,ownerExt->collisionGroup) == 0) // Matching collision groups
-                    return 0;
-            }
-            else
-            {
-                ExtendedBlockFields* blockExt = Blocks::GetRawExtended(blockIdx);
+            if (!gCollisionMatrix.getGroupsCollide(ext->collisionGroup,ownerExt->collisionGroup)) // Check collision matrix
+                return 0;
+        }
+        else
+        {
+            ExtendedBlockFields* blockExt = Blocks::GetRawExtended(blockIdx);
 
-                if (strcmp(ext->collisionGroup,blockExt->collisionGroup) == 0) // Matching collision groups
-                    return 0;
-            }
+            if (!gCollisionMatrix.getGroupsCollide(ext->collisionGroup,blockExt->collisionGroup)) // Check collision matrix
+                return 0;
         }
     }
 
@@ -3680,14 +3678,10 @@ static unsigned int __stdcall runtimeHookNPCCollisionGroupInternal(int npcAIdx, 
         return 0; // Collision cancelled
     
     ExtendedNPCFields* extA = NPC::GetRawExtended(npcAIdx);
+    ExtendedNPCFields* extB = NPC::GetRawExtended(npcBIdx);
 
-    if (extA->collisionGroup[0] != 0) // Collision group string isn't empty
-    {
-        ExtendedNPCFields* extB = NPC::GetRawExtended(npcBIdx);
-
-        if (strcmp(extA->collisionGroup,extB->collisionGroup) == 0) // Matching collision groups
-            return 0; // Collision cancelled
-    }
+    if (!gCollisionMatrix.getGroupsCollide(extA->collisionGroup,extB->collisionGroup)) // Check collision matrix
+        return 0; // Collision cancelled
 
     return -1; // Collision goes ahead
 }

--- a/LunaDll/Misc/RuntimeHookComponents/RuntimeHookHooks.cpp
+++ b/LunaDll/Misc/RuntimeHookComponents/RuntimeHookHooks.cpp
@@ -573,6 +573,9 @@ extern void __stdcall NPCKillHook(short* npcIndex_ptr, short* killReason)
         short newIdx = npcIdx - 1;    // 0 based not including dummy
         short oldIdx = GM_NPCS_COUNT; // 0 based not including dummy
 
+        // Decrement the reference count of the removed NPC's collision group
+        gCollisionMatrix.decrementReferenceCount(NPC::GetRawExtended(newIdx+1)->collisionGroup);
+
         // Update extended NPC fields
         if (newIdx != oldIdx)
         {
@@ -3637,14 +3640,14 @@ static unsigned int __stdcall runtimeHookBlockNPCFilterInternal(unsigned int hit
         {
             ExtendedNPCFields* ownerExt = NPC::GetRawExtended(block->OwnerNPCIdx);
 
-            if (!gCollisionMatrix.getGroupsCollide(ext->collisionGroup,ownerExt->collisionGroup)) // Check collision matrix
+            if (!gCollisionMatrix.getIndicesCollide(ext->collisionGroup,ownerExt->collisionGroup)) // Check collision matrix
                 return 0;
         }
         else
         {
             ExtendedBlockFields* blockExt = Blocks::GetRawExtended(blockIdx);
 
-            if (!gCollisionMatrix.getGroupsCollide(ext->collisionGroup,blockExt->collisionGroup)) // Check collision matrix
+            if (!gCollisionMatrix.getIndicesCollide(ext->collisionGroup,blockExt->collisionGroup)) // Check collision matrix
                 return 0;
         }
     }
@@ -3680,7 +3683,7 @@ static unsigned int __stdcall runtimeHookNPCCollisionGroupInternal(int npcAIdx, 
     ExtendedNPCFields* extA = NPC::GetRawExtended(npcAIdx);
     ExtendedNPCFields* extB = NPC::GetRawExtended(npcBIdx);
 
-    if (!gCollisionMatrix.getGroupsCollide(extA->collisionGroup,extB->collisionGroup)) // Check collision matrix
+    if (!gCollisionMatrix.getIndicesCollide(extA->collisionGroup,extB->collisionGroup)) // Check collision matrix
         return 0; // Collision cancelled
 
     return -1; // Collision goes ahead

--- a/LunaDll/SMBXInternal/Blocks.h
+++ b/LunaDll/SMBXInternal/Blocks.h
@@ -4,7 +4,7 @@
 #include "BaseItemArray.h"
 #include "../Defines.h"
 #include "../Misc/VB6StrPtr.h"
-#include "Misc/CollisionMatrix.h"
+#include "../Misc/CollisionMatrix.h"
 struct PlayerMOB;
 
 #pragma pack(push, 4)

--- a/LunaDll/SMBXInternal/Blocks.h
+++ b/LunaDll/SMBXInternal/Blocks.h
@@ -58,7 +58,7 @@ struct ExtendedBlockFields
     double layerSpeedY;
     double extraSpeedX;
     double extraSpeedY;
-    char collisionGroup[collisionGroupStringLength];
+    unsigned int collisionGroup;
 
     // Constructor
     ExtendedBlockFields()
@@ -73,7 +73,7 @@ struct ExtendedBlockFields
         layerSpeedY = 0.0;
         extraSpeedX = 0.0;
         extraSpeedY = 0.0;
-        collisionGroup[0] = '\0';
+        collisionGroup = 0u;
     }
 };
 

--- a/LunaDll/SMBXInternal/Blocks.h
+++ b/LunaDll/SMBXInternal/Blocks.h
@@ -4,6 +4,7 @@
 #include "BaseItemArray.h"
 #include "../Defines.h"
 #include "../Misc/VB6StrPtr.h"
+#include "Misc/CollisionMatrix.h"
 struct PlayerMOB;
 
 #pragma pack(push, 4)
@@ -57,7 +58,7 @@ struct ExtendedBlockFields
     double layerSpeedY;
     double extraSpeedX;
     double extraSpeedY;
-    char collisionGroup[32];
+    char collisionGroup[collisionGroupStringLength];
 
     // Constructor
     ExtendedBlockFields()

--- a/LunaDll/SMBXInternal/NPCs.h
+++ b/LunaDll/SMBXInternal/NPCs.h
@@ -7,6 +7,7 @@
 #include <string>
 #include "../Defines.h"
 #include "../Misc/VB6StrPtr.h"
+#include "Misc/CollisionMatrix.h"
 
 
 enum NPCID : short
@@ -521,7 +522,7 @@ static_assert(sizeof(NPCMOB) == 0x158, "sizeof(NPCMOB) must be 0x158");
 struct ExtendedNPCFields
 {
     bool noblockcollision;
-    char collisionGroup[32];
+    char collisionGroup[collisionGroupStringLength];
 
     // Constructor
     ExtendedNPCFields()

--- a/LunaDll/SMBXInternal/NPCs.h
+++ b/LunaDll/SMBXInternal/NPCs.h
@@ -522,7 +522,7 @@ static_assert(sizeof(NPCMOB) == 0x158, "sizeof(NPCMOB) must be 0x158");
 struct ExtendedNPCFields
 {
     bool noblockcollision;
-    char collisionGroup[collisionGroupStringLength];
+    unsigned int collisionGroup;
 
     // Constructor
     ExtendedNPCFields()
@@ -534,7 +534,7 @@ struct ExtendedNPCFields
     void Reset()
     {
         noblockcollision = false;
-        collisionGroup[0] = '\0';
+        collisionGroup = 0u;
     }
 };
 

--- a/LunaDll/SMBXInternal/NPCs.h
+++ b/LunaDll/SMBXInternal/NPCs.h
@@ -7,7 +7,7 @@
 #include <string>
 #include "../Defines.h"
 #include "../Misc/VB6StrPtr.h"
-#include "Misc/CollisionMatrix.h"
+#include "../Misc/CollisionMatrix.h"
 
 
 enum NPCID : short


### PR DESCRIPTION
Improves MDA's collision groups systems (#40) by adding a collision matrix.

Requires changes to [`ffi_misc.lua`](https://gist.github.com/Supermario1313/3a576ea8b86858f250f0e87b9533f63f).

![2023-10-07_02_09_29](https://github.com/WohlSoft/LunaLua/assets/12142048/7e107450-1732-4c28-97fb-7085658ef53e)
