### PR TITLE
Fix regsvr32 shell command

### DIFF
--- a/LunaDll/Misc/RuntimeHookComponents/RuntimeHookGeneral.cpp
+++ b/LunaDll/Misc/RuntimeHookComponents/RuntimeHookGeneral.cpp
@@ -2147,8 +2147,7 @@ void TrySkipPatch()
         .Apply();
     
     // Add a space between /s and the argument
-    static wchar_t const fixed_regsvr32_string[] = L"regsvr32 /s ";
     PATCH(0x8BEAE9)
-        .PUSH_IMM32((std::uint32_t) &fixed_regsvr32_string)
+        .PUSH_IMM32((std::uint32_t) L"regsvr32 /s ")
         .Apply();
 }

--- a/LunaDll/Misc/RuntimeHookComponents/RuntimeHookGeneral.cpp
+++ b/LunaDll/Misc/RuntimeHookComponents/RuntimeHookGeneral.cpp
@@ -2145,4 +2145,10 @@ void TrySkipPatch()
         .bytes(0x84, 0xC0) // test al, al
         .bytes(0x74, 0x35) // jz 0x8CDF00
         .Apply();
+    
+    // Add a space between /s and the argument
+    static wchar_t const fixed_regsvr32_string[] = L"regsvr32 /s ";
+    PATCH(0x8BEAE9)
+        .PUSH_IMM32((std::uint32_t) &fixed_regsvr32_string)
+        .Apply();
 }


### PR DESCRIPTION
Adds a space after `/s` in [the `regsvr32` shell command which registers `mswinsck.ocx`](https://github.com/smbx/smbx-legacy-source/blob/4a7ff946da8924d2268f6ee8d824034f3a7d7658/modMain.bas#L1292C51-L1292C63). Fixes an error with Wine 8.21.