### PR TITLE
Extended player fields

### DIFF
--- a/LunaDll/FileManager/LoadFile_Level.cpp
+++ b/LunaDll/FileManager/LoadFile_Level.cpp
@@ -128,6 +128,7 @@ void LunaLua_loadLevelFile(LevelData &outData, std::wstring fullPath, bool isVal
     // Clear extended fields
     NPC::ClearExtendedFields();
     Blocks::ClearExtendedFields();
+    Player::ClearExtendedFields();
 
     // We should clear the anim array apparently though
     memset(GM_ANIM_PTR, 0, 1000*sizeof(SMBXAnimation));

--- a/LunaDll/LuaMain/LuaProxyFFI.cpp
+++ b/LunaDll/LuaMain/LuaProxyFFI.cpp
@@ -469,7 +469,7 @@ typedef struct ExtendedPlayerFields_\
     bool noblockcollision;\
     bool nonpcinteraction;\
     bool noplayerinteraction;\
-    char collisionGroup[32];\
+    unsigned int collisionGroup;\
 } ExtendedPlayerFields;";
     }
 

--- a/LunaDll/LuaMain/LuaProxyFFI.cpp
+++ b/LunaDll/LuaMain/LuaProxyFFI.cpp
@@ -456,6 +456,23 @@ typedef struct ExtendedBlockFields_\
 } ExtendedBlockFields;";
     }
 
+    FFI_EXPORT(ExtendedPlayerFields*) LunaLuaGetPlayerExtendedFieldsArray()
+    {
+        return Player::GetExtended(0);
+    }
+
+    FFI_EXPORT(const char*) LunaLuaGetPlayerExtendedFieldsStruct()
+    {
+        return "\
+typedef struct ExtendedPlayerFields_\
+{\
+    bool noblockcollision;\
+    bool nonpcinteraction;\
+    bool noplayerinteraction;\
+    char collisionGroup[32];\
+} ExtendedPlayerFields;";
+    }
+
     FFI_EXPORT(unsigned int) LunaLuaCollisionMatrixAllocateIndex()
     {
         return gCollisionMatrix.allocateIndex();

--- a/LunaDll/Misc/RuntimeHook.h
+++ b/LunaDll/Misc/RuntimeHook.h
@@ -596,6 +596,10 @@ void __stdcall runtimeHookNPCNoBlockCollisionA1760E(void);
 void __stdcall runtimeHookNPCNoBlockCollisionA1B33F(void);
 
 void __stdcall runtimeHookBlockPlayerFilter(void);
+void __stdcall runtimeHookPlayerNPCInteractionCheck(void);
+void __stdcall runtimeHookPlayerNPCCollisionCheck9AE8FA(void);
+void __stdcall runtimeHookPlayerNPCCollisionCheck9ABC0B(void);
+void __stdcall runtimeHookPlayerPlayerInteraction(void);
 
 void __stdcall runtimeHookBlockNPCFilter(void);
 void __stdcall runtimeHookNPCCollisionGroup(void);

--- a/LunaDll/Misc/RuntimeHookComponents/RuntimeHookGeneral.cpp
+++ b/LunaDll/Misc/RuntimeHookComponents/RuntimeHookGeneral.cpp
@@ -2062,7 +2062,16 @@ void TrySkipPatch()
 
     // Patch to handle blocks that allow players to pass through
     // Moved from where the original code does it to allow player passthrough slopes
+    // Also handles collision groups
     PATCH(0x9A16E8).JMP(runtimeHookBlockPlayerFilter).NOP_PAD_TO_SIZE<12>().Apply();
+
+    // Collision group handling for player-to-NPC collision
+    PATCH(0x9A79EF).JMP(runtimeHookPlayerNPCInteractionCheck).NOP_PAD_TO_SIZE<9>().Apply();
+    PATCH(0x9AE8FA).JMP(runtimeHookPlayerNPCCollisionCheck9AE8FA).NOP_PAD_TO_SIZE<15>().Apply();
+    PATCH(0x9ABC0B).JMP(runtimeHookPlayerNPCCollisionCheck9ABC0B).NOP_PAD_TO_SIZE<6>().Apply();
+
+    // Collision group handling for player-to-player collision
+    PATCH(0x9CAFC4).JMP(runtimeHookPlayerPlayerInteraction).NOP_PAD_TO_SIZE<6>().Apply();
 
     // Patch to handle blocks that allow NPCs to pass through
     // Also handles collisionGroup for NPC-to-solid interactions now

--- a/LunaDll/Misc/RuntimeHookComponents/RuntimeHookHooks.cpp
+++ b/LunaDll/Misc/RuntimeHookComponents/RuntimeHookHooks.cpp
@@ -3804,7 +3804,12 @@ static unsigned int __stdcall runtimeHookBlockPlayerFilterInternal(short playerI
     }
     
     // Collision groups
-    // PLACEHOLDER
+    ExtendedBlockFields* blockExt = Blocks::GetRawExtended(blockIdx);
+
+    if (!gCollisionMatrix.getIndicesCollide(playerExt->collisionGroup,blockExt->collisionGroup)) // Check collision matrix
+    {
+        return 0;
+    }
 
     // No filter needed, carry on
     return -1;
@@ -3855,7 +3860,12 @@ static unsigned int __stdcall runtimeHookPlayerNPCInteractionCheckInternal(short
     }
 
     // Collision groups
-    // PLACEHOLDER
+    ExtendedNPCFields* npcExt = NPC::GetRawExtended(npcIdx);
+
+    if (!gCollisionMatrix.getIndicesCollide(playerExt->collisionGroup,npcExt->collisionGroup)) // Check collision matrix
+    {
+        return 0;
+    }
 
     return -1;
 }
@@ -3952,15 +3962,17 @@ __declspec(naked) void __stdcall runtimeHookPlayerNPCCollisionCheck9ABC0B(void)
 
 static unsigned int __stdcall runtimeHookPlayerPlayerInteractionInternal(short* playerAIdxPtr, short playerBIdx)
 {
-    // Don't interact if it's the same NPC
+    // Don't interact if it's the same player
     // This hook replaces the code that would normally handle this
-    if (*playerAIdxPtr == playerBIdx)
+    short playerAIdx = *playerAIdxPtr;
+
+    if (playerAIdx == playerBIdx)
     {
         return 0;
     }
 
     // noplayerinteraction flag
-    ExtendedPlayerFields* extA = Player::GetExtended(*playerAIdxPtr);
+    ExtendedPlayerFields* extA = Player::GetExtended(playerAIdx);
     ExtendedPlayerFields* extB = Player::GetExtended(playerBIdx);
 
     if (extA->noplayerinteraction || extB->noplayerinteraction)
@@ -3969,7 +3981,10 @@ static unsigned int __stdcall runtimeHookPlayerPlayerInteractionInternal(short* 
     }
 
     // Collision groups
-    // PLACEHOLDER
+    if (!gCollisionMatrix.getIndicesCollide(extA->collisionGroup,extB->collisionGroup)) // Check collision matrix
+    {
+        return 0;
+    }
 
     return -1;
 }

--- a/LunaDll/Misc/RuntimeHookComponents/RuntimeHookHooks.cpp
+++ b/LunaDll/Misc/RuntimeHookComponents/RuntimeHookHooks.cpp
@@ -3907,6 +3907,9 @@ __declspec(naked) void __stdcall runtimeHookPlayerNPCCollisionCheck9AE8FA(void)
 {
     // Handles collision from the sides/bottom
     __asm {
+        cmp word ptr ds:[edx+ecx*0x8 + 0x136], 0   // check the projectile flag (this is what the code that this replaces does)
+        jne cancel_collision
+
         movsx eax, word ptr ss:[ebp-0x114]
         push eax                // Player index
 

--- a/LunaDll/Misc/RuntimeHookComponents/RuntimeHookHooks.cpp
+++ b/LunaDll/Misc/RuntimeHookComponents/RuntimeHookHooks.cpp
@@ -3955,7 +3955,7 @@ __declspec(naked) void __stdcall runtimeHookPlayerNPCCollisionCheck9ABC0B(void)
         push 0x9ABC11
         ret
     cancel_collision:
-        push 0x9ADCDB
+        push 0x9AD246 // jumps to code for handling other hit spots
         ret
     }
 }

--- a/LunaDll/SMBXInternal/PlayerMOB.cpp
+++ b/LunaDll/SMBXInternal/PlayerMOB.cpp
@@ -9,6 +9,25 @@ PlayerMOB* Player::Get(int index) {
 }
 
 
+static ExtendedPlayerFields g_extendedPlayerFields[201];
+
+ExtendedPlayerFields* Player::GetExtended(int index)
+{
+    if (index < 0 || index >= 201)
+        return nullptr;
+
+    return &g_extendedPlayerFields[index];
+}
+
+void Player::ClearExtendedFields()
+{
+    for (int i = 0; i < 201; i++)
+    {
+        g_extendedPlayerFields[i].Reset();
+    }
+}
+
+
 // MANAGEMENT
 bool Player::InternalSwap(int player1, int player2) {
     char temp[500];

--- a/LunaDll/SMBXInternal/PlayerMOB.h
+++ b/LunaDll/SMBXInternal/PlayerMOB.h
@@ -386,12 +386,39 @@ static_assert(offsetof(PlayerMOB, Unknown166) == 0x166, "Unknown166 must be at a
 static_assert(sizeof(PlayerMOB) == 0x184, "sizeof(PlayerMOB) must be 0x184");
 #endif
 
+// Extra player fields
+struct ExtendedPlayerFields
+{
+    bool noblockcollision;
+    bool nonpcinteraction;
+    bool noplayerinteraction;
+    char collisionGroup[32];
+
+    // Constructor
+    ExtendedPlayerFields()
+    {
+        Reset();
+    }
+
+    // Reset function
+    void Reset()
+    {
+        noblockcollision = false;
+        nonpcinteraction = false;
+        noplayerinteraction = false;
+        collisionGroup[0] = '\0';
+    }
+};
+
 namespace Player {
 
     /// Player functions ///
 
     // PLAYER ACCESS -- (Currently only returns the ptr to the main player)
     PlayerMOB* Get(int player);
+
+    ExtendedPlayerFields* GetExtended(int index);
+    void ClearExtendedFields();
 
     // PLAYER MANAGEMENT
     bool InternalSwap(int player1, int player2); // swaps position of two players in the object list

--- a/LunaDll/SMBXInternal/PlayerMOB.h
+++ b/LunaDll/SMBXInternal/PlayerMOB.h
@@ -392,7 +392,7 @@ struct ExtendedPlayerFields
     bool noblockcollision;
     bool nonpcinteraction;
     bool noplayerinteraction;
-    char collisionGroup[32];
+    unsigned int collisionGroup;
 
     // Constructor
     ExtendedPlayerFields()
@@ -406,7 +406,7 @@ struct ExtendedPlayerFields
         noblockcollision = false;
         nonpcinteraction = false;
         noplayerinteraction = false;
-        collisionGroup[0] = '\0';
+        collisionGroup = 0u;
     }
 };
 


### PR DESCRIPTION
Adds the collision group system to players, along with the following boolean fields: noblockcollision, nonpcinteraction and noplayerinteraction.

![2024-01-02_14_16_57](https://github.com/WohlSoft/LunaLua/assets/59939907/7f974f93-b361-48b1-a350-a56c516d61e8)
