### PR TITLE
Fix hidden fences being climbable

### DIFF
--- a/LunaDll/Misc/RuntimeHookComponents/RuntimeHookGeneral.cpp
+++ b/LunaDll/Misc/RuntimeHookComponents/RuntimeHookGeneral.cpp
@@ -1298,7 +1298,7 @@ static auto fenceFixesImpl = PatchCollection(
     .bytes(0x0F, 0x1F, 0x00), // nop
 
     PATCH(0x9A74CB)
-    .bytes(0x66, 0x39, 0x74, 0xCA, 0x04) // cmp word ptr [edx + ecx * 8 + 0x4], si ; compare isHidden to the si register, which is equal to COMBOOL(false)
+    .bytes(0x66, 0x39, 0x74, 0xCA, 0x04) // cmp word ptr [edx + ecx * 8 + 0x4], si ; compare isHidden to the si register, which is equal to COMBOOL(true)
     .bytes(0x0F, 0x84, 0xE0, 0x03, 0x00, 0x00) // je 0x9A78B6 ; skip the current iteration if the layer is invisible
     .bytes(0x0F, 0x1F, 0x00) // nop
 );

--- a/LunaDll/Misc/RuntimeHookComponents/RuntimeHookGeneral.cpp
+++ b/LunaDll/Misc/RuntimeHookComponents/RuntimeHookGeneral.cpp
@@ -1295,6 +1295,11 @@ static auto fenceFixesImpl = PatchCollection(
     .PUSH_EBP()
     .PUSH_ESI()
     .CALL(runtimeHookUpdateBGOMomentum)
+    .bytes(0x0F, 0x1F, 0x00), // nop
+
+    PATCH(0x9A74CB)
+    .bytes(0x66, 0x39, 0x74, 0xCA, 0x04) // cmp word ptr [edx + ecx * 8 + 0x4], si ; compare isHidden to the si register, which is equal to COMBOOL(false)
+    .bytes(0x0F, 0x84, 0xE0, 0x03, 0x00, 0x00) // je 0x9A78B6 ; skip the current iteration if the layer is invisible
     .bytes(0x0F, 0x1F, 0x00) // nop
 );
 Patchable& gFenceFixes = fenceFixesImpl;

--- a/LunaDll/Misc/RuntimeHookComponents/RuntimeHookGeneral.cpp
+++ b/LunaDll/Misc/RuntimeHookComponents/RuntimeHookGeneral.cpp
@@ -1299,7 +1299,7 @@ static auto fenceFixesImpl = PatchCollection(
 
     PATCH(0x9A74CB)
     .bytes(0x66, 0x39, 0x74, 0xCA, 0x04) // cmp word ptr [edx + ecx * 8 + 0x4], si ; compare isHidden to the si register, which is equal to COMBOOL(true)
-    .bytes(0x0F, 0x84, 0xE0, 0x03, 0x00, 0x00) // je 0x9A78B6 ; skip the current iteration if the layer is invisible
+    .JE(0x9A78B6) // skip the current iteration if the layer is invisible
     .bytes(0x0F, 0x1F, 0x00) // nop
 );
 Patchable& gFenceFixes = fenceFixesImpl;


### PR DESCRIPTION
This fix can be disabled with `Misc.SetFenceBugFix`.
![2024-01-20_02_33_19](https://github.com/WohlSoft/LunaLua/assets/12142048/9f40eaae-a10d-4949-a7f5-349a8f5a380d)
