### PR TITLE
NPC ceiling bug fix

### DIFF
--- a/LunaDll/LuaMain/LuaProxyFFI.cpp
+++ b/LunaDll/LuaMain/LuaProxyFFI.cpp
@@ -533,6 +533,18 @@ typedef struct ExtendedPlayerFields_\
         }
     }
 
+    FFI_EXPORT(void) LunaLuaSetNPCCeilingBugFix(bool enable)
+    {
+        if (enable)
+        {
+            gNPCCeilingBugFix.Apply();
+        }
+        else
+        {
+            gNPCCeilingBugFix.Unapply();
+        }
+    }
+
     FFI_EXPORT(void) LunaLuaSetNPCSectionFix(bool enable)
     {
         if (enable)

--- a/LunaDll/LuaMain/LunaLuaMain.cpp
+++ b/LunaDll/LuaMain/LunaLuaMain.cpp
@@ -133,6 +133,7 @@ bool CLunaLua::shutdown()
     gDisablePlayerDownwardClipFix.Apply();
     gDisableNPCDownwardClipFix.Apply();
     gDisableNPCDownwardClipFixSlope.Apply();
+    gNPCCeilingBugFix.Apply();
     gNPCSectionFix.Apply();
     gFenceFixes.Apply();
     gLinkFairyClowncarFixes.Apply();

--- a/LunaDll/Misc/RuntimeHook.h
+++ b/LunaDll/Misc/RuntimeHook.h
@@ -39,6 +39,7 @@ void TrySkipPatch();
 extern AsmPatch<777> gDisablePlayerDownwardClipFix;
 extern AsmPatch<8> gDisableNPCDownwardClipFix;
 extern AsmPatch<6> gDisableNPCDownwardClipFixSlope;
+extern AsmPatch<21> gNPCCeilingBugFix;
 extern Patchable& gNPCSectionFix;
 extern Patchable& gFenceFixes;
 extern Patchable& gLinkFairyClowncarFixes;

--- a/LunaDll/Misc/RuntimeHookComponents/RuntimeHookGeneral.cpp
+++ b/LunaDll/Misc/RuntimeHookComponents/RuntimeHookGeneral.cpp
@@ -1266,6 +1266,8 @@ static unsigned int __stdcall LatePatch(void)
 AsmPatch<777> gDisablePlayerDownwardClipFix = PATCH(0x9A3FD3).JMP(runtimeHookCompareWalkBlockForPlayerWrapper).NOP_PAD_TO_SIZE<777>();
 AsmPatch<8> gDisableNPCDownwardClipFix = PATCH(0xA16B82).JMP(runtimeHookCompareNPCWalkBlock).NOP_PAD_TO_SIZE<8>();
 
+AsmPatch<21> gNPCCeilingBugFix = PATCH(0xA17155).NOP_PAD_TO_SIZE<21>();
+
 // NOTE: This patch replaces a section 167 bytes long from 0xA13188 to 0xA1322E, but we don't NOP out the whole thing
 //       since that would conflict with NpcIdExtender, and this patch may be turned on/off at runtime.
 AsmPatch<6> gDisableNPCDownwardClipFixSlope = PATCH(0xA13188).JMP(runtimeHookNPCWalkFixSlope).NOP_PAD_TO_SIZE<6>();
@@ -2082,6 +2084,9 @@ void TrySkipPatch()
 
     // Hook to fix an NPC's section property when it spawn out of bounds
     gNPCSectionFix.Apply();
+
+    // Hook to fix erroneous Y speed after an NPC hits a ceiling
+    gNPCCeilingBugFix.Apply(); 
 
     // Patch to handle block reorder after p-switch handling
     PATCH(0x9E441A).JMP(runtimeHookAfterPSwitchBlocksReorderedWrapper).NOP_PAD_TO_SIZE<242>().Apply();


### PR DESCRIPTION
Fixes NPCs often getting an incorrect vertical speed assigned when hitting a ceiling. Just NOPs out the chunk of code that moves ``B`` into the edi register, thus allowing ``winningBlock`` to stay in place ([relevant source](https://github.com/smbx/smbx-legacy-source/blob/master/modNPC.bas#L2187-L2190)). Revertible by an FFI function. Thanks, of course, to ds-sloth for finding and explaining the cause of the issue!