### PR TITLE
Function to get the state of a controller's stick

### DIFF
--- a/LunaDll/Input/LunaGameController.cpp
+++ b/LunaDll/Input/LunaGameController.cpp
@@ -486,6 +486,26 @@ std::string LunaGameControllerManager::getSelectedControllerName(int playerNum)
     return "Keyboard";
 }
 
+int LunaGameControllerManager::getSelectedControllerStickX(int playerNum)
+{
+    LunaGameController* controller = getController(playerNum);
+    if (controller != nullptr)
+    {
+        return controller->getStickX();
+    }
+    return 0;
+}
+
+int LunaGameControllerManager::getSelectedControllerStickY(int playerNum)
+{
+    LunaGameController* controller = getController(playerNum);
+    if (controller != nullptr)
+    {
+        return controller->getStickY();
+    }
+    return 0;
+}
+
 void LunaGameControllerManager::rumbleSelectedController(int playerNum, int ms, float strength)
 {
     LunaGameController* controller = getController(playerNum);
@@ -660,6 +680,8 @@ LunaGameController::LunaGameController(LunaGameControllerManager* _managerPtr, S
     axisPadState(0),
     padState(0),
     buttonState(0),
+    xAxis(0),
+    yAxis(0),
     activeFlag(false),
     joyButtonMap()
 {
@@ -773,6 +795,8 @@ LunaGameController::LunaGameController(LunaGameController &&other)
     axisPadState    = other.axisPadState;
     padState        = other.padState;
     buttonState     = other.buttonState;
+    xAxis           = other.xAxis;
+    yAxis           = other.yAxis;
     activeFlag      = other.activeFlag;
     joyButtonMap    = other.joyButtonMap;
     other.joyPtr    = nullptr;
@@ -795,6 +819,8 @@ LunaGameController & LunaGameController::operator=(LunaGameController &&other)
     axisPadState    = other.axisPadState;
     padState        = other.padState;
     buttonState     = other.buttonState;
+    xAxis           = other.xAxis;
+    yAxis           = other.yAxis;
     activeFlag      = other.activeFlag;
     joyButtonMap    = other.joyButtonMap;
     other.joyPtr    = nullptr;
@@ -986,11 +1012,13 @@ void LunaGameController::controllerAxisEvent(const SDL_ControllerAxisEvent& even
         axisAsDirectional = true;
         posPadNumber = CONTROLLER_PAD_RIGHT;
         negPadNumber = CONTROLLER_PAD_LEFT;
+        xAxis = (int)event.value;
         break;
     case SDL_CONTROLLER_AXIS_LEFTY:
         axisAsDirectional = true;
         posPadNumber = CONTROLLER_PAD_DOWN;
         negPadNumber = CONTROLLER_PAD_UP;
+        yAxis = (int)event.value;
         break;
     default:
         break;

--- a/LunaDll/Input/LunaGameController.cpp
+++ b/LunaDll/Input/LunaGameController.cpp
@@ -1,5 +1,6 @@
 #include <SDL2/SDL.h>
 #include <memory>
+#include <tuple>
 #include "LunaGameController.h"
 #if !defined(BUILDING_SMBXLAUNCHER)
 #   ifdef _WIN32
@@ -486,24 +487,14 @@ std::string LunaGameControllerManager::getSelectedControllerName(int playerNum)
     return "Keyboard";
 }
 
-int LunaGameControllerManager::getSelectedControllerStickX(int playerNum)
+std::tuple<int, int> LunaGameControllerManager::getSelectedControllerStickPosition(int playerNum)
 {
     LunaGameController* controller = getController(playerNum);
     if (controller != nullptr)
     {
-        return controller->getStickX();
+        return controller->getStickPosition();
     }
-    return 0;
-}
-
-int LunaGameControllerManager::getSelectedControllerStickY(int playerNum)
-{
-    LunaGameController* controller = getController(playerNum);
-    if (controller != nullptr)
-    {
-        return controller->getStickY();
-    }
-    return 0;
+    return {0, 0};
 }
 
 void LunaGameControllerManager::rumbleSelectedController(int playerNum, int ms, float strength)

--- a/LunaDll/Input/LunaGameController.h
+++ b/LunaDll/Input/LunaGameController.h
@@ -3,6 +3,7 @@
 
 #include <SDL2/SDL.h>
 #include <vector>
+#include <tuple>
 #include <unordered_map>
 
 struct joyinfoex_tag;
@@ -55,8 +56,7 @@ public:
     inline void clearActive() { activeFlag = false; }
     inline unsigned int getPadState() const { return padState; }
     inline unsigned int getButtonState() const { return buttonState; }
-    inline int getStickX() const { return static_cast<int>(xAxis); }
-    inline int getStickY() const { return static_cast<int>(yAxis); }
+    inline std::tuple<int, int> getStickPosition() const { return {xAxis, yAxis}; }
 
     SDL_JoystickPowerLevel getPowerLevel();
 
@@ -117,8 +117,8 @@ private:
     unsigned int axisPadState;
     unsigned int padState;
     unsigned int buttonState;
-    unsigned int xAxis;
-    unsigned int yAxis;
+    int xAxis;
+    int yAxis;
     bool activeFlag;
     std::vector<int> joyButtonMap;
 };
@@ -160,8 +160,7 @@ public:
 public:
     SDL_JoystickPowerLevel getSelectedControllerPowerLevel(int playerNum);
     std::string getSelectedControllerName(int playerNum);
-    int getSelectedControllerStickX(int playerNum);
-    int getSelectedControllerStickY(int playerNum);
+    std::tuple<int, int> getSelectedControllerStickPosition(int playerNum);
     void rumbleSelectedController(int playerNum, int ms, float strength);
     LunaGameController* getController(int playerNum);
 private:

--- a/LunaDll/Input/LunaGameController.h
+++ b/LunaDll/Input/LunaGameController.h
@@ -55,6 +55,8 @@ public:
     inline void clearActive() { activeFlag = false; }
     inline unsigned int getPadState() const { return padState; }
     inline unsigned int getButtonState() const { return buttonState; }
+    inline int getStickX() const { return static_cast<int>(xAxis); }
+    inline int getStickY() const { return static_cast<int>(yAxis); }
 
     SDL_JoystickPowerLevel getPowerLevel();
 
@@ -115,6 +117,8 @@ private:
     unsigned int axisPadState;
     unsigned int padState;
     unsigned int buttonState;
+    unsigned int xAxis;
+    unsigned int yAxis;
     bool activeFlag;
     std::vector<int> joyButtonMap;
 };
@@ -156,6 +160,8 @@ public:
 public:
     SDL_JoystickPowerLevel getSelectedControllerPowerLevel(int playerNum);
     std::string getSelectedControllerName(int playerNum);
+    int getSelectedControllerStickX(int playerNum);
+    int getSelectedControllerStickY(int playerNum);
     void rumbleSelectedController(int playerNum, int ms, float strength);
     LunaGameController* getController(int playerNum);
 private:

--- a/LunaDll/LuaMain/LuaProxyFFI.cpp
+++ b/LunaDll/LuaMain/LuaProxyFFI.cpp
@@ -408,6 +408,16 @@ extern "C" {
         return (int)SDL_JOYSTICK_POWER_UNKNOWN;
     }
 
+    struct StickPos
+    {
+        int x;
+        int y;
+    };
+    FFI_EXPORT(StickPos) LunaLuaGetSelectedControllerStickPosition(int playerNum)
+    {
+        return {gLunaGameControllerManager.getSelectedControllerStickX(playerNum), gLunaGameControllerManager.getSelectedControllerStickY(playerNum)};
+    }
+
     FFI_EXPORT(const char*) LunaLuaGetSelectedControllerName(int playerNum)
     {
         static std::string name;

--- a/LunaDll/LuaMain/LuaProxyFFI.cpp
+++ b/LunaDll/LuaMain/LuaProxyFFI.cpp
@@ -415,7 +415,9 @@ extern "C" {
     };
     FFI_EXPORT(StickPos) LunaLuaGetSelectedControllerStickPosition(int playerNum)
     {
-        return {gLunaGameControllerManager.getSelectedControllerStickX(playerNum), gLunaGameControllerManager.getSelectedControllerStickY(playerNum)};
+        const auto stickPos = gLunaGameControllerManager.getSelectedControllerStickPosition(playerNum);
+
+        return {std::get<0>(stickPos), std::get<1>(stickPos)};
     }
 
     FFI_EXPORT(const char*) LunaLuaGetSelectedControllerName(int playerNum)


### PR DESCRIPTION
Adds Misc.GetSelectedControllerStickPosition, returning two X/Y values, each within the range of -1 to 1 (though conversion to that range is done Lua-side).

Since I'm largely unfamiliar with how controller handling is done internally, it's possible that I've gone about this in a weird way. Let me know if there is some clear way of improving this.