### PR TITLE
Fix onTick/onTickEnd/etc. running during section resizing

### DIFF
--- a/LunaDll/EventStateMachine.cpp
+++ b/LunaDll/EventStateMachine.cpp
@@ -104,7 +104,7 @@ void EventStateMachine::reset(void) {
 }
 
 void EventStateMachine::hookLevelLoop(void) {
-    if (gLunaLua.isValid() && (gLunaLua.getType() == CLunaLua::LUNALUA_LEVEL))
+    if (gLunaLua.isValid() && (gLunaLua.getType() == CLunaLua::LUNALUA_LEVEL) && !SMBX13::Vars::qScreen)
     {
         // Check if we should pause
         checkPause();


### PR DESCRIPTION
Simple fix to check qScreen before calling tick-related events.