### PR TITLE
onNPCTransform fixes

### DIFF
--- a/LunaDll/Misc/AsmPatch.h
+++ b/LunaDll/Misc/AsmPatch.h
@@ -11,11 +11,22 @@
 template<void* TARGETADDR>
 _declspec(naked) static void __stdcall RETADDR_TRACE_HOOK_IMPL(void)
 {
+#ifdef __clang__
+    __asm__ volatile (
+        ".intel_syntax noprefix\n"
+        "push dword ptr [ds : esp]\n"
+        "jmp %c[thisPtr]"
+        ".att_syntax\n"
+        :
+        : [thisPtr] "i" (TARGETADDR)
+    );
+#else
     static const void* thisPtr = TARGETADDR;
     __asm {
         PUSH DWORD PTR DS : [esp]
         JMP thisPtr
     }
+#endif
 }
 
 template<void* TARGETADDR>

--- a/LunaDll/Misc/RuntimeHook.h
+++ b/LunaDll/Misc/RuntimeHook.h
@@ -382,7 +382,7 @@ void __stdcall runtimeHookPOW();
 void __stdcall runtimeHookCollectNPC(short* playerIdx, short* npcIdx);
 
 void __stdcall runtimeHookNPCTransformRandomVeggie(void);
-void __stdcall runtimeHookNPCTransformSprout(void);
+void __stdcall runtimeHookNPCTransformSprout(short* pNpcIdx);
 void __stdcall runtimeHookNPCTransformRandomBonus(void);
 void __stdcall runtimeHookNPCTransformMushToHeart(void);
 void __stdcall runtimeHookNPCTransformCoinToRupee(void);

--- a/LunaDll/Misc/RuntimeHookComponents/RuntimeHookGeneral.cpp
+++ b/LunaDll/Misc/RuntimeHookComponents/RuntimeHookGeneral.cpp
@@ -1853,7 +1853,7 @@ void TrySkipPatch()
     // Hooks for onNPCTransform support
     PATCH(0xA0ACBC).JMP(&runtimeHookNPCTransformRandomVeggie).NOP().NOP().Apply(); // When the randomized veggie spawns
     PATCH(0x9CCB41).CALL(&runtimeHookNPCTransformSprout).Apply(); // When pulling a sprout from the ground
-    PATCH(0xA45556).JMP(&runtimeHookNPCTransformRandomBonus).NOP_PAD_TO_SIZE<9>().Apply(); // Random powerup NPC
+    PATCH(0xA45556).CALL(&runtimeHookNPCTransformRandomBonus).bytes(0x0F, 0x1F, 0x40, 0x00 /* nop */).Apply(); // Random powerup NPC
     PATCH(0xA6133A).JMP(&runtimeHookNPCTransformMushToHeart).NOP_PAD_TO_SIZE<10>().Apply(); // Link mushrooms to hearts
     PATCH(0xA6101C).JMP(&runtimeHookNPCTransformCoinToRupee).NOP_PAD_TO_SIZE<10>().Apply(); // Link coins to rupees
     PATCH(0xA0B719).JMP(&runtimeHookNPCTransformSnifitBulletToSMB2Coin).NOP_PAD_TO_SIZE<6>().Apply(); // Snifit bulllet to coin when held

--- a/LunaDll/Misc/RuntimeHookComponents/RuntimeHookGeneral.cpp
+++ b/LunaDll/Misc/RuntimeHookComponents/RuntimeHookGeneral.cpp
@@ -1852,7 +1852,7 @@ void TrySkipPatch()
 
     // Hooks for onNPCTransform support
     PATCH(0xA0ACBC).JMP(&runtimeHookNPCTransformRandomVeggie).NOP().NOP().Apply(); // When the randomized veggie spawns
-    PATCH(0x9CCB40).JMP(&runtimeHookNPCTransformSprout).NOP_PAD_TO_SIZE<6>().Apply(); // When pulling a sprout from the ground
+    PATCH(0x9CCB41).CALL(&runtimeHookNPCTransformSprout).Apply(); // When pulling a sprout from the ground
     PATCH(0xA45556).JMP(&runtimeHookNPCTransformRandomBonus).NOP_PAD_TO_SIZE<9>().Apply(); // Random powerup NPC
     PATCH(0xA6133A).JMP(&runtimeHookNPCTransformMushToHeart).NOP_PAD_TO_SIZE<10>().Apply(); // Link mushrooms to hearts
     PATCH(0xA6101C).JMP(&runtimeHookNPCTransformCoinToRupee).NOP_PAD_TO_SIZE<10>().Apply(); // Link coins to rupees

--- a/LunaDll/Misc/RuntimeHookComponents/RuntimeHookGeneral.cpp
+++ b/LunaDll/Misc/RuntimeHookComponents/RuntimeHookGeneral.cpp
@@ -1861,7 +1861,7 @@ void TrySkipPatch()
     PATCH(0xA45E0A).CALL(&runtimeHookNPCTransformBubblePopped).NOP_PAD_TO_SIZE<24>().Apply(); // Bubble popped, transformed to contents
     PATCH(0xA45954).CALL(&runtimeHookNPCTransformSMWSpinyEgg).NOP_PAD_TO_SIZE<28>().Apply(); // SMW spiny egg landed
     PATCH(0xA483C3).JMP(&runtimeHookNPCTransformLudwigShell).NOP_PAD_TO_SIZE<5>().Apply(); // Ludwig enter shell (modNpc.bas line 9465)
-    PATCH(0xA5217F).JMP(&runtimeHookNPCTransformKoopalingUnshell).NOP_PAD_TO_SIZE<5>().Apply(); // Koopaling leave shell
+    PATCH(0xA5205C).JMP(&runtimeHookNPCTransformKoopalingUnshell).NOP_PAD_TO_SIZE<6>().Apply(); // Koopaling leave shell (modNpc.bas line 9253)
     PATCH(0xA55500).CALL(&runtimeHookNPCTransformPotionToDoor).NOP_PAD_TO_SIZE<16>().Apply(); // Potion transform to door
     PATCH(0xA5B77E).JMP(&runtimeHookNPCTransformGaloombaUnflip).NOP_PAD_TO_SIZE<17>().Apply(); // Galoomba unflipped
     PATCH(0x9E3632).CALL(&runtimeHookNPCTransformPSwitchResetRupeeCoins).NOP_PAD_TO_SIZE<8>().Apply(); // When pressing a p switch, rupees transformed by link are turned back into coins

--- a/LunaDll/Misc/RuntimeHookComponents/RuntimeHookGeneral.cpp
+++ b/LunaDll/Misc/RuntimeHookComponents/RuntimeHookGeneral.cpp
@@ -1863,7 +1863,7 @@ void TrySkipPatch()
     PATCH(0xA483C3).JMP(&runtimeHookNPCTransformLudwigShell).NOP_PAD_TO_SIZE<5>().Apply(); // Ludwig enter shell (modNpc.bas line 9465)
     PATCH(0xA5217F).JMP(&runtimeHookNPCTransformKoopalingUnshell).NOP_PAD_TO_SIZE<5>().Apply(); // Koopaling leave shell
     PATCH(0xA55500).CALL(&runtimeHookNPCTransformPotionToDoor).NOP_PAD_TO_SIZE<16>().Apply(); // Potion transform to door
-    PATCH(0xA5B77E).JMP(&runtimeHookNPCTransformGaloombaUnflip).NOP_PAD_TO_SIZE<11>().Apply(); // Galoomba unflipped
+    PATCH(0xA5B77E).JMP(&runtimeHookNPCTransformGaloombaUnflip).NOP_PAD_TO_SIZE<17>().Apply(); // Galoomba unflipped
     PATCH(0x9E3632).CALL(&runtimeHookNPCTransformPSwitchResetRupeeCoins).NOP_PAD_TO_SIZE<8>().Apply(); // When pressing a p switch, rupees transformed by link are turned back into coins
     PATCH(0xA19B1E).CALL(&runtimeHookNPCTransformSMWKoopaEnterShell).NOP_PAD_TO_SIZE<8>().Apply(); // SMW koopa entering shell, overwrites a bounds check
     PATCH(0x9BE698).CALL(&runtimeHookNPCTransformYoshiEatRandomVeggie).NOP_PAD_TO_SIZE<7>().Apply(); // Incredibly niche code path for Yoshi eating a randomized veggie

--- a/LunaDll/Misc/RuntimeHookComponents/RuntimeHookGeneral.cpp
+++ b/LunaDll/Misc/RuntimeHookComponents/RuntimeHookGeneral.cpp
@@ -1860,7 +1860,7 @@ void TrySkipPatch()
     PATCH(0xA0B38D).CALL(&runtimeHookNPCTransformHeldYoshiToEgg).NOP_PAD_TO_SIZE<34>().Apply(); // Yoshis to eggs when held
     PATCH(0xA45E0A).CALL(&runtimeHookNPCTransformBubblePopped).NOP_PAD_TO_SIZE<24>().Apply(); // Bubble popped, transformed to contents
     PATCH(0xA45954).CALL(&runtimeHookNPCTransformSMWSpinyEgg).NOP_PAD_TO_SIZE<28>().Apply(); // SMW spiny egg landed
-    PATCH(0xA483C3).JMP(&runtimeHookNPCTransformLudwigShell).NOP_PAD_TO_SIZE<5>().Apply(); // Ludwig enter shell
+    PATCH(0xA483C3).JMP(&runtimeHookNPCTransformLudwigShell).NOP_PAD_TO_SIZE<5>().Apply(); // Ludwig enter shell (modNpc.bas line 9465)
     PATCH(0xA5217F).JMP(&runtimeHookNPCTransformKoopalingUnshell).NOP_PAD_TO_SIZE<5>().Apply(); // Koopaling leave shell
     PATCH(0xA55500).CALL(&runtimeHookNPCTransformPotionToDoor).NOP_PAD_TO_SIZE<16>().Apply(); // Potion transform to door
     PATCH(0xA5B77E).JMP(&runtimeHookNPCTransformGaloombaUnflip).NOP_PAD_TO_SIZE<11>().Apply(); // Galoomba unflipped

--- a/LunaDll/Misc/RuntimeHookComponents/RuntimeHookNPCTransform.cpp
+++ b/LunaDll/Misc/RuntimeHookComponents/RuntimeHookNPCTransform.cpp
@@ -105,7 +105,7 @@ void __stdcall runtimeHookNPCTransformSprout(short* pNpcIdx)
     executeOnNPCTransformIdx((int)*pNpcIdx, 91, NPC_TFCAUSE_CONTAINER);
 }
 
-void __stdcall runtimeHookNPCTransformRandomBonus_internal(NPCMOB* npc, int newType)
+void __stdcall runtimeHookNPCTransformRandomBonus_internal(NPCMOB* npc, short newType)
 {
     // replicate the basegame code that this hook overwrites
     npc->id = newType;
@@ -115,22 +115,12 @@ const static int _transformRandomBonusJmpDestination = 0xA4555F;
 _declspec(naked) void __stdcall runtimeHookNPCTransformRandomBonus()
 {
     __asm {
-        pushfd
-        push ebx
-        push ecx
-        push edx
-        push esi
         push eax // new NPC type
         push esi // address of the NPC in memory
         call runtimeHookNPCTransformRandomBonus_internal
-        pop esi
-        pop edx
-        pop ecx
-        pop ebx
-        popfd
 
         lea ecx, dword ptr ss : [ebp - 0x1EC] // instruction overwritten by this code
-        jmp _transformRandomBonusJmpDestination
+        ret
     }
 }
 

--- a/LunaDll/Misc/RuntimeHookComponents/RuntimeHookNPCTransform.cpp
+++ b/LunaDll/Misc/RuntimeHookComponents/RuntimeHookNPCTransform.cpp
@@ -143,22 +143,12 @@ void __stdcall runtimeHookNPCTransformMushToHeart_internal(int npcIdx)
     // invoke transformation event
     executeOnNPCTransformIdx(npcIdx + 1, oldID, NPC_TFCAUSE_LINK);
 }
-const static int _transformMushToHeartJmpDestination = 0xA615F5;
 _declspec(naked) void __stdcall runtimeHookNPCTransformMushToHeart()
 {
     __asm {
-        pushfd
-        push ebx
-        push ecx
-        push esi
         push esi // NPC IDX
-        call runtimeHookNPCTransformMushToHeart_internal
-        pop esi
-        pop ecx
-        pop ebx
-        popfd
-
-        jmp _transformMushToHeartJmpDestination
+        push 0xA615F5 // Return address
+        jmp runtimeHookNPCTransformMushToHeart_internal
     }
 }
 

--- a/LunaDll/Misc/RuntimeHookComponents/RuntimeHookNPCTransform.cpp
+++ b/LunaDll/Misc/RuntimeHookComponents/RuntimeHookNPCTransform.cpp
@@ -56,7 +56,7 @@ void executeOnNPCTransformIdx(int npcIdx, int oldID, NPCTransformationCause caus
 }
 // invoke the event using the NPCMOB* pointer
 // kind of ugly but it works
-void executeOnNPCTransformPtr(NPCMOB* npc, int oldID, NPCTransformationCause cause)
+void __stdcall  executeOnNPCTransformPtr(NPCMOB* npc, int oldID, NPCTransformationCause cause)
 {
     executeOnNPCTransformIdx(((int)(npc - (NPCMOB*)GM_NPCS_PTR) - 128), oldID, cause);
 }
@@ -312,24 +312,14 @@ _declspec(naked) void __stdcall runtimeHookNPCTransformSMWSpinyEgg()
 
 
 
-void __stdcall runtimeHookNPCTransformLudwigShell_internal(NPCMOB* npc)
-{
-    executeOnNPCTransformPtr(npc, 280, NPC_TFCAUSE_AI);
-}
-const static int _transformLudwigShellJmpDestination = 0xA5211F;
 _declspec(naked) void __stdcall runtimeHookNPCTransformLudwigShell()
 {
     __asm {
-        push ebx
-        push ecx
-        push esi
+        push NPC_TFCAUSE_AI // Transformation cause
+        push 280 // Old ID
         push esi // NPC ptr
-        call runtimeHookNPCTransformLudwigShell_internal
-        pop esi
-        pop ecx
-        pop ebx
-
-        jmp _transformLudwigShellJmpDestination
+        push 0xA5211F // Return address
+        jmp executeOnNPCTransformPtr
     }
 }
 

--- a/LunaDll/Misc/RuntimeHookComponents/RuntimeHookNPCTransform.cpp
+++ b/LunaDll/Misc/RuntimeHookComponents/RuntimeHookNPCTransform.cpp
@@ -329,20 +329,12 @@ void __stdcall runtimeHookNPCTransformKoopalingUnshell_internal(NPCMOB* npc)
 {
     executeOnNPCTransformPtr(npc, npc->id + 1, NPC_TFCAUSE_AI);
 }
-const static int _transformKoopalingUnshellJmpDestination = 0xA52B74;
 _declspec(naked) void __stdcall runtimeHookNPCTransformKoopalingUnshell()
 {
     __asm {
-        push ebx
-        push ecx
-        push esi
         push esi // NPC ptr
-        call runtimeHookNPCTransformKoopalingUnshell_internal
-        pop esi
-        pop ecx
-        pop ebx
-
-        jmp _transformKoopalingUnshellJmpDestination
+        push 0xA52B74 // Return address
+        jmp runtimeHookNPCTransformKoopalingUnshell_internal
     }
 }
 

--- a/LunaDll/Misc/RuntimeHookComponents/RuntimeHookNPCTransform.cpp
+++ b/LunaDll/Misc/RuntimeHookComponents/RuntimeHookNPCTransform.cpp
@@ -297,13 +297,23 @@ _declspec(naked) void __stdcall runtimeHookNPCTransformLudwigShell()
 
 void __stdcall runtimeHookNPCTransformKoopalingUnshell_internal(NPCMOB* npc)
 {
-    executeOnNPCTransformPtr(npc, npc->id + 1, NPC_TFCAUSE_AI);
+    short oldId = npc->id;
+
+    // replicate the basegame code that this hook overwrites
+    npc->momentum.x += npc->momentum.width / 2;
+    npc->momentum.y += npc->momentum.height;
+    npc->id--;
+    npc->momentum.width = npc_width[npc->id];
+    npc->momentum.height = npc_height[npc->id];
+    npc->momentum.x -= npc->momentum.width / 2;
+    npc->momentum.y -= npc->momentum.height;
+    executeOnNPCTransformPtr(npc, oldId, NPC_TFCAUSE_AI);
 }
 _declspec(naked) void __stdcall runtimeHookNPCTransformKoopalingUnshell()
 {
     __asm {
         push esi // NPC ptr
-        push 0xA52B74 // Return address
+        push 0xA52179 // Return address
         jmp runtimeHookNPCTransformKoopalingUnshell_internal
     }
 }

--- a/LunaDll/Misc/RuntimeHookComponents/RuntimeHookNPCTransform.cpp
+++ b/LunaDll/Misc/RuntimeHookComponents/RuntimeHookNPCTransform.cpp
@@ -97,37 +97,13 @@ _declspec(naked) void __stdcall runtimeHookNPCTransformRandomVeggie()
     }
 }
 
-void __stdcall runtimeHookNPCTransformSprout_internal(short* pNpcIdx)
+void __stdcall runtimeHookNPCTransformSprout(short* pNpcIdx)
 {
     // replicate the basegame code that this hook overwrites
     native_setNPCFrame(pNpcIdx);
     // invoke transformation event
     executeOnNPCTransformIdx((int)*pNpcIdx, 91, NPC_TFCAUSE_CONTAINER);
 }
-const static int _transformSprouteJmpDestination = 0x9CCB46;
-_declspec(naked) void __stdcall runtimeHookNPCTransformSprout()
-{
-    __asm {
-        pushfd
-        push eax
-        push ebx
-        push ecx
-        push edx
-        push esi
-        push ecx // pointer to npc index
-        call runtimeHookNPCTransformSprout_internal
-        pop esi
-        pop edx
-        pop ecx
-        pop ebx
-        pop eax
-        popfd
-
-        jmp _transformSprouteJmpDestination
-    }
-}
-
-
 
 void __stdcall runtimeHookNPCTransformRandomBonus_internal(NPCMOB* npc, int newType)
 {

--- a/LunaDll/Misc/RuntimeHookComponents/RuntimeHookNPCTransform.cpp
+++ b/LunaDll/Misc/RuntimeHookComponents/RuntimeHookNPCTransform.cpp
@@ -175,22 +175,12 @@ void __stdcall runtimeHookNPCTransformCoinToRupee_internal(int npcIdx)
     // invoke transformation event
     executeOnNPCTransformIdx(npcIdx + 1, oldID, NPC_TFCAUSE_LINK);
 }
-const static int _transformCoinToRupeeJmpDestination = 0xA61335;
 _declspec(naked) void __stdcall runtimeHookNPCTransformCoinToRupee()
 {
     __asm {
-        pushfd
-        push ebx
-        push ecx
-        push esi
         push esi // NPC IDX
-        call runtimeHookNPCTransformCoinToRupee_internal
-        pop esi
-        pop ecx
-        pop ebx
-        popfd
-
-        jmp _transformCoinToRupeeJmpDestination
+        push 0xA615F5 // Return address
+        jmp runtimeHookNPCTransformCoinToRupee_internal
     }
 }
 

--- a/LunaDll/Misc/RuntimeHookComponents/RuntimeHookNPCTransform.cpp
+++ b/LunaDll/Misc/RuntimeHookComponents/RuntimeHookNPCTransform.cpp
@@ -369,19 +369,12 @@ void __stdcall runtimeHookNPCTransformGaloombaUnflip_internal(NPCMOB* npc)
     // invoke transformation event
     executeOnNPCTransformPtr(npc, 166, NPC_TFCAUSE_AI);
 }
-const static int _transformGaloombaUnflipJmpDestination = 0xA5C14E;
 _declspec(naked) void __stdcall runtimeHookNPCTransformGaloombaUnflip()
 {
     __asm {
-        push ebx
-        push ecx
-        push esi
         push esi // NPC ptr
-        call runtimeHookNPCTransformGaloombaUnflip_internal
-        pop esi
-        pop ecx
-        pop ebx
-        jmp _transformGaloombaUnflipJmpDestination
+        push 0xA5C14E // Return address
+        jmp runtimeHookNPCTransformGaloombaUnflip_internal
     }
 }
 

--- a/LunaDll/Misc/RuntimeHookComponents/RuntimeHookNPCTransform.cpp
+++ b/LunaDll/Misc/RuntimeHookComponents/RuntimeHookNPCTransform.cpp
@@ -198,22 +198,12 @@ void __stdcall runtimeHookNPCTransformSnifitBulletToSMB2Coin_internal(NPCMOB* np
     npc->momentum.y -= npc->momentum.height / 2;
     executeOnNPCTransformPtr(npc, 133, NPC_TFCAUSE_AI);
 }
-const static int _transformSnifitBulletToSMB2CoinJmpDestination = 0xA0B875;
 _declspec(naked) void __stdcall runtimeHookNPCTransformSnifitBulletToSMB2Coin()
 {
     __asm {
-        pushfd
-        push ebx
-        push ecx
-        push esi
         push esi // NPC ptr
-        call runtimeHookNPCTransformSnifitBulletToSMB2Coin_internal
-        pop esi
-        pop ecx
-        pop ebx
-        popfd
-
-        jmp _transformSnifitBulletToSMB2CoinJmpDestination
+        push 0xA0B875 // Return address
+        jmp runtimeHookNPCTransformSnifitBulletToSMB2Coin_internal
     }
 }
 


### PR DESCRIPTION
`jmp`ing to a constant in MSVC-style inline assembly has a different behavior depending on whether it's compiled with MSVC or Clang. In MSVC, it compiles to a jump to the address contained in the constant while in Clang, it jumps to the address of the constant itself, which causes a page fault since we're trying to execute non-executable memory. This implementation-dependent behavior causes certain actions, like pulling grass, to cause a crash on LunaLua builds compiled with Clang.

This pull request replaces all instances of `jmp`s to constants by equivalent code modulo certain simplifications, like removing `push`/`pop` pairs when registers don't need to be saved. All of them are found in the implementation of the `onNPCTransform` event, except for one which is located in the unused function `RETADDR_TRACE_HOOK_IMPL`.