### PR TITLE
"nonpcinteraction" and "walkpastnpcs"

### DIFF
--- a/LunaDll/LuaMain/LuaProxyFFI.cpp
+++ b/LunaDll/LuaMain/LuaProxyFFI.cpp
@@ -446,7 +446,7 @@ extern "C" {
 typedef struct ExtendedNPCFields_\
 {\
     bool noblockcollision;\
-    bool nonpccollision;\
+    bool nonpcinteraction;\
     short fullyInsideSection;\
     unsigned int collisionGroup;\
 } ExtendedNPCFields;";

--- a/LunaDll/Misc/RuntimeHook.h
+++ b/LunaDll/Misc/RuntimeHook.h
@@ -615,6 +615,7 @@ void __stdcall runtimeHookPlayerPlayerInteraction(void);
 
 void __stdcall runtimeHookBlockNPCFilter(void);
 void __stdcall runtimeHookNPCCollisionGroup(void);
+void __stdcall runtimeHookWalkPastNPCs(void);
 
 void __stdcall runtimeHookLevelPauseCheck(void);
 

--- a/LunaDll/Misc/RuntimeHookComponents/RuntimeHookGeneral.cpp
+++ b/LunaDll/Misc/RuntimeHookComponents/RuntimeHookGeneral.cpp
@@ -2137,6 +2137,9 @@ void TrySkipPatch()
     // Patch to handle collisionGroup for NPC-to-NPC interactions, and harmlessthrown flag
     PATCH(0xA181AD).JMP(runtimeHookNPCCollisionGroup).NOP_PAD_TO_SIZE<6>().Apply();
 
+    // Patch to handle walkpastnpcs config for NPCs
+    PATCH(0xA1B801).JMP(runtimeHookWalkPastNPCs).NOP_PAD_TO_SIZE<724>().Apply();
+
     // Replace pause button detection code to avoid re-triggering when held
     PATCH(0x8CA405).JMP(runtimeHookLevelPauseCheck).NOP_PAD_TO_SIZE<6>().Apply();
 

--- a/LunaDll/SMBXInternal/NPCs.cpp
+++ b/LunaDll/SMBXInternal/NPCs.cpp
@@ -274,6 +274,7 @@ static int16_t npcprop_notcointransformable[NPC::MAX_ID + 1] = { 0 };
 static int16_t npcprop_staticdirection[NPC::MAX_ID + 1] = { 0 };
 static int16_t npcprop_luahandlesspeed[NPC::MAX_ID + 1] = { 0 };
 static int16_t npcprop_nonpcinteraction[NPC::MAX_ID + 1] = { 0 };
+static int16_t npcprop_walkpastnpcs[NPC::MAX_ID + 1] = { 0 };
 static double npcprop_terminalvelocity[NPC::MAX_ID + 1] = { 0 };
 
 // Other NPC-related config data, not by ID
@@ -295,6 +296,7 @@ void NPC::InitProperties() {
         npcprop_staticdirection[i] = 0;
         npcprop_luahandlesspeed[i] = 0;
         npcprop_nonpcinteraction[i] = 0;
+        npcprop_walkpastnpcs[i] = 0;
         npcprop_terminalvelocity[i] = 0;
     }
 
@@ -502,6 +504,12 @@ void NPC::InitProperties() {
     npcprop_staticdirection[181] = -1;
     npcprop_staticdirection[212] = -1;
 
+    // Default walkpastnpcs values
+    npcprop_walkpastnpcs[13] = 1;
+    npcprop_walkpastnpcs[17] = 1;
+    npcprop_walkpastnpcs[265] = 1;
+    npcprop_walkpastnpcs[179] = 2;
+
     // Default terminal velocity values
     npcprop_terminalvelocity[259] = -1;
     npcprop_terminalvelocity[260] = -1;
@@ -571,6 +579,11 @@ bool NPC::GetNoNPCInteraction(int id) {
     return (npcprop_nonpcinteraction[id] != 0);
 }
 
+int16_t NPC::GetWalkPastNPCs(int id) {
+    if ((id < 1) || (id > NPC::MAX_ID)) return 0;
+    return npcprop_walkpastnpcs[id];
+}
+
 double NPC::GetTerminalVelocity(int id) {
     if ((id < 1) || (id > NPC::MAX_ID) || (npcprop_terminalvelocity[id] == 0))
     {
@@ -631,6 +644,9 @@ uintptr_t NPC::GetPropertyTableAddress(const std::string& s)
     }
     else if (s == "nonpcinteraction") {
         return reinterpret_cast<uintptr_t>(npcprop_nonpcinteraction);
+    }
+    else if (s == "walkpastnpcs") {
+        return reinterpret_cast<uintptr_t>(npcprop_walkpastnpcs);
     }
     else if (s == "terminalvelocity")
     {

--- a/LunaDll/SMBXInternal/NPCs.cpp
+++ b/LunaDll/SMBXInternal/NPCs.cpp
@@ -273,6 +273,7 @@ static int16_t npcprop_noshieldfireeffect[NPC::MAX_ID + 1] = { 0 };
 static int16_t npcprop_notcointransformable[NPC::MAX_ID + 1] = { 0 };
 static int16_t npcprop_staticdirection[NPC::MAX_ID + 1] = { 0 };
 static int16_t npcprop_luahandlesspeed[NPC::MAX_ID + 1] = { 0 };
+static int16_t npcprop_nonpcinteraction[NPC::MAX_ID + 1] = { 0 };
 static double npcprop_terminalvelocity[NPC::MAX_ID + 1] = { 0 };
 
 // Other NPC-related config data, not by ID
@@ -293,6 +294,7 @@ void NPC::InitProperties() {
         npcprop_notcointransformable[i] = 0;
         npcprop_staticdirection[i] = 0;
         npcprop_luahandlesspeed[i] = 0;
+        npcprop_nonpcinteraction[i] = 0;
         npcprop_terminalvelocity[i] = 0;
     }
 
@@ -564,6 +566,11 @@ bool NPC::GetLuaHandlesSpeed(int id) {
     return (npcprop_luahandlesspeed[id] != 0);
 }
 
+bool NPC::GetNoNPCInteraction(int id) {
+    if ((id < 1) || (id > NPC::MAX_ID)) return false;
+    return (npcprop_nonpcinteraction[id] != 0);
+}
+
 double NPC::GetTerminalVelocity(int id) {
     if ((id < 1) || (id > NPC::MAX_ID) || (npcprop_terminalvelocity[id] == 0))
     {
@@ -621,6 +628,9 @@ uintptr_t NPC::GetPropertyTableAddress(const std::string& s)
     else if (s == "luahandlesspeed")
     {
         return reinterpret_cast<uintptr_t>(npcprop_luahandlesspeed);
+    }
+    else if (s == "nonpcinteraction") {
+        return reinterpret_cast<uintptr_t>(npcprop_nonpcinteraction);
     }
     else if (s == "terminalvelocity")
     {

--- a/LunaDll/SMBXInternal/NPCs.h
+++ b/LunaDll/SMBXInternal/NPCs.h
@@ -586,6 +586,7 @@ namespace NPC {
     bool GetStaticDirection(int id);
     bool GetLuaHandlesSpeed(int id);
     bool GetNoNPCInteraction(int id);
+    int16_t GetWalkPastNPCs(int id);
     double GetTerminalVelocity(int id);
 
     uintptr_t GetPropertyTableAddress(const std::string& s);

--- a/LunaDll/SMBXInternal/NPCs.h
+++ b/LunaDll/SMBXInternal/NPCs.h
@@ -522,7 +522,7 @@ static_assert(sizeof(NPCMOB) == 0x158, "sizeof(NPCMOB) must be 0x158");
 struct ExtendedNPCFields
 {
     bool noblockcollision;
-    bool nonpccollision;
+    bool nonpcinteraction;
     short fullyInsideSection;
     unsigned int collisionGroup;
 
@@ -538,7 +538,7 @@ struct ExtendedNPCFields
         noblockcollision = false;
         fullyInsideSection = -1;
         collisionGroup = 0u;
-        nonpccollision = false;
+        nonpcinteraction = false;
     }
 };
 
@@ -585,6 +585,7 @@ namespace NPC {
     bool GetNotCoinTransformable(int id);
     bool GetStaticDirection(int id);
     bool GetLuaHandlesSpeed(int id);
+    bool GetNoNPCInteraction(int id);
     double GetTerminalVelocity(int id);
 
     uintptr_t GetPropertyTableAddress(const std::string& s);


### PR DESCRIPTION
Renames the "nonpccollision" field that Sarn added to "nonpcinteraction" for consistency with the player field, and gives it a corresponding config setting. Also makes it so that NPCs with it set will ignore block-like NPCs too.

Adds "walkpastnpcs", which specifically controls the bumping behaviour between two NPCs. It can have three values:
- 0: turns around as normal
- 1: other NPCs will bump off of it as usual, but it won't turn around
- 2: ignored entirely

Side note: this technically comes with a minuscule change to how fireballs and ice balls (and bullet bills modified via config) bump off of things. But it doesn't seem to make a practical difference.