### PR TITLE
onNPCTransform fix (Patch 4 version)

### DIFF
--- a/LunaDll/Misc/RuntimeHookComponents/RuntimeHookGeneral.cpp
+++ b/LunaDll/Misc/RuntimeHookComponents/RuntimeHookGeneral.cpp
@@ -1843,7 +1843,7 @@ void TrySkipPatch()
     PATCH(0xA45E0A).CALL(&runtimeHookNPCTransformBubblePopped).NOP_PAD_TO_SIZE<24>().Apply(); // Bubble popped, transformed to contents
     PATCH(0xA45954).CALL(&runtimeHookNPCTransformSMWSpinyEgg).NOP_PAD_TO_SIZE<28>().Apply(); // SMW spiny egg landed
     PATCH(0xA483C3).JMP(&runtimeHookNPCTransformLudwigShell).NOP_PAD_TO_SIZE<5>().Apply(); // Ludwig enter shell
-    PATCH(0xA5217F).JMP(&runtimeHookNPCTransformKoopalingUnshell).NOP_PAD_TO_SIZE<5>().Apply(); // Koopaling leave shell
+    PATCH(0xA5205C).JMP(&runtimeHookNPCTransformKoopalingUnshell).NOP_PAD_TO_SIZE<6>().Apply(); // Koopaling leave shell
     PATCH(0xA55500).CALL(&runtimeHookNPCTransformPotionToDoor).NOP_PAD_TO_SIZE<16>().Apply(); // Potion transform to door
     PATCH(0xA5B77E).JMP(&runtimeHookNPCTransformGaloombaUnflip).NOP_PAD_TO_SIZE<11>().Apply(); // Galoomba unflipped
     PATCH(0x9E3632).CALL(&runtimeHookNPCTransformPSwitchResetRupeeCoins).NOP_PAD_TO_SIZE<8>().Apply(); // When pressing a p switch, rupees transformed by link are turned back into coins

--- a/LunaDll/Misc/RuntimeHookComponents/RuntimeHookNPCTransform.cpp
+++ b/LunaDll/Misc/RuntimeHookComponents/RuntimeHookNPCTransform.cpp
@@ -371,20 +371,24 @@ _declspec(naked) void __stdcall runtimeHookNPCTransformLudwigShell()
 
 void __stdcall runtimeHookNPCTransformKoopalingUnshell_internal(NPCMOB* npc)
 {
-    executeOnNPCTransformPtr(npc, npc->id + 1, NPC_TFCAUSE_AI);
+    short oldId = npc->id;
+
+    // replicate the basegame code that this hook overwrites
+    npc->momentum.x += npc->momentum.width / 2; 
+    npc->momentum.y += npc->momentum.height;
+    npc->id--;
+    npc->momentum.width = npc_width[npc->id];
+    npc->momentum.height = npc_height[npc->id];
+    npc->momentum.x -= npc->momentum.width / 2;
+    npc->momentum.y -= npc->momentum.height;
+    executeOnNPCTransformPtr(npc, oldId, NPC_TFCAUSE_AI);
 }
-const static int _transformKoopalingUnshellJmpDestination = 0xA52B74;
+const static int _transformKoopalingUnshellJmpDestination = 0xA52179;
 _declspec(naked) void __stdcall runtimeHookNPCTransformKoopalingUnshell()
 {
     __asm {
-        push ebx
-        push ecx
-        push esi
         push esi // NPC ptr
         call runtimeHookNPCTransformKoopalingUnshell_internal
-        pop esi
-        pop ecx
-        pop ebx
 
         jmp _transformKoopalingUnshellJmpDestination
     }


### PR DESCRIPTION
This PR contains the `onNPCTransform` fix introduced by #83 without the clang fixes as requested by @ds-sloth.